### PR TITLE
Irq rework master

### DIFF
--- a/cmake/depends.cmake
+++ b/cmake/depends.cmake
@@ -10,7 +10,7 @@ if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     collect (PROJECT_INC_DIRS "${HUGETLBFS_INCLUDE_DIR}")
     collect (PROJECT_LIB_DEPS "${HUGETLBFS_LIBRARIES}")
     add_definitions(-DHAVE_HUGETLBFS_H)
-  endif(HugeTLBFS_FOUND)
+  endif(HUGETLBFS_FOUND)
 
   find_package (LibSysFS REQUIRED)
   collect (PROJECT_INC_DIRS "${LIBSYSFS_INCLUDE_DIR}")

--- a/cmake/platforms/zynqmp-linux.cmake
+++ b/cmake/platforms/zynqmp-linux.cmake
@@ -1,4 +1,4 @@
-set (CMAKE_SYSTEM_PROCESSOR "arm64"              CACHE STRING "")
+set (CMAKE_SYSTEM_PROCESSOR "aarch64"            CACHE STRING "")
 set (CROSS_PREFIX           "aarch64-linux-gnu-" CACHE STRING "")
 include (cross-linux-gcc)
 

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/ipi_latency_demod.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/ipi_latency_demod.c
@@ -232,8 +232,8 @@ int ipi_latency_demod()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ipi_dev, &ch);
+	/* unregister IPI irq handler */
+	metal_irq_unregister(ipi_irq, 0, ipi_dev, &ch);
 
 out:
 	return ret;

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/ipi_shmem_demod.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/ipi_shmem_demod.c
@@ -296,8 +296,8 @@ int ipi_shmem_demod()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ipi_dev, ipi_io);
+	/* unregister IPI irq handler */
+	metal_irq_unregister(ipi_irq, 0, ipi_dev, ipi_io);
 
 out:
 	return ret;

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_atomic_demod.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_atomic_demod.c
@@ -164,8 +164,8 @@ int atomic_shmem_demod()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ipi_dev, ipi_io);
+	/* unregister IPI irq handler */
+	metal_irq_unregister(ipi_irq, 0, ipi_dev, ipi_io);
 
 out:
 	return ret;

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_latency_demod.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_latency_demod.c
@@ -279,8 +279,8 @@ int shmem_latency_demod()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ipi_dev, &ch);
+	/* unregister IPI irq handler */
+	metal_irq_unregister(ipi_irq, 0, ipi_dev, &ch);
 
 out:
 	return ret;

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_throughput_demod.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_throughput_demod.c
@@ -369,8 +369,8 @@ int shmem_throughput_demod()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ipi_dev, &ch);
+	/* unregister IPI irq handler */
+	metal_irq_unregister(ipi_irq, 0, ipi_dev, &ch);
 
 out:
 	return ret;

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/ipi_latency_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/ipi_latency_demod.c
@@ -232,8 +232,8 @@ int ipi_latency_demod()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ipi_dev, &ch);
+	/* unregister IPI irq handler */
+	metal_irq_unregister(ipi_irq, 0, ipi_dev, &ch);
 
 out:
 	return ret;

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/ipi_shmem_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/ipi_shmem_demod.c
@@ -296,8 +296,8 @@ int ipi_shmem_demod()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ipi_dev, ipi_io);
+	/* unregister IPI irq handler */
+	metal_irq_unregister(ipi_irq, 0, ipi_dev, ipi_io);
 
 out:
 	return ret;

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_atomic_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_atomic_demod.c
@@ -164,8 +164,8 @@ int atomic_shmem_demod()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ipi_dev, ipi_io);
+	/* unregister IPI irq handler */
+	metal_irq_unregister(ipi_irq, 0, ipi_dev, ipi_io);
 
 out:
 	return ret;

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_latency_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_latency_demod.c
@@ -279,8 +279,8 @@ int shmem_latency_demod()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ipi_dev, &ch);
+	/* unregister IPI irq handler */
+	metal_irq_unregister(ipi_irq, 0, ipi_dev, &ch);
 
 out:
 	return ret;

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_throughput_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_throughput_demod.c
@@ -369,8 +369,8 @@ int shmem_throughput_demod()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ipi_dev, &ch);
+	/* unregister IPI irq handler */
+	metal_irq_unregister(ipi_irq, 0, ipi_dev, &ch);
 
 out:
 	return ret;

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/ipi_latency_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/ipi_latency_demo.c
@@ -303,8 +303,8 @@ int ipi_latency_demo()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ch.ipi_dev, &ch);
+	/* unregister IPI irq handler by setting the handler to 0 */
+	metal_irq_unregister(ipi_irq, 0, ch.ipi_dev, &ch);
 
 out:
 	if (ch.ttc_dev)

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/ipi_shmem_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/ipi_shmem_demo.c
@@ -401,8 +401,8 @@ int ipi_shmem_demo()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ipi_dev, ipi_io);
+	/* unregister IPI irq handler by setting the handler to 0 */
+	metal_irq_unregister(ipi_irq, 0, ipi_dev, ipi_io);
 
 out:
 	if (shm_dev)

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_atomic_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_atomic_demo.c
@@ -192,8 +192,8 @@ int atomic_shmem_demo()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ipi_dev, ipi_io);
+	/* unregister IPI irq handler by setting the handler to 0 */
+	metal_irq_unregister(ipi_irq, 0, ipi_dev, ipi_io);
 
 out:
 	if (shm_dev)

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_latency_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_latency_demo.c
@@ -361,8 +361,8 @@ int shmem_latency_demo()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ch.ipi_dev, &ch);
+	/* unregister IPI irq handler by setting the handler to 0 */
+	metal_irq_unregister(ipi_irq, 0, ch.ipi_dev, &ch);
 
 out:
 	if (ch.ttc_dev)

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_throughput_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_throughput_demo.c
@@ -379,6 +379,8 @@ static int measure_shmem_throughput(struct channel_s* ch)
 			s * iterations * TTC_CLK_FREQ_HZ / rpu_rx_count[i] / MB);
 	}
 
+	LPRINTF("Finished shared memory throughput\n");
+
 out:
 	if (lbuf)
 		metal_free_memory(lbuf);
@@ -475,8 +477,8 @@ int shmem_throughput_demo()
 
 	/* disable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IDR_OFFSET, IPI_MASK);
-	/* deregister IPI irq handler by setting the handler to 0 */
-	metal_irq_register(ipi_irq, 0, ch.ipi_dev, &ch);
+	/* unregister IPI irq handler by setting the handler to 0 */
+	metal_irq_unregister(ipi_irq, 0, ch.ipi_dev, &ch);
 
 out:
 	if (ch.ttc_dev)

--- a/lib/irq.h
+++ b/lib/irq.h
@@ -60,19 +60,33 @@ typedef int (*metal_irq_handler) (int irq, void *priv);
 struct metal_device;
 
 /**
- * @brief      Register interrupt or register interrupt handling of a
- *             specific interrupt.
+ * @brief      Register interrupt handler for driver ID/device.
  *
- *             If the interrupt handler parameter (irq_handler) is NULL,
- *	       deregister the interrupt handler.
+ * @param[in]  irq         interrupt id
+ * @param[in]  irq_handler interrupt handler
+ * @param[in]  dev         metal device this irq belongs to (can be NULL).
+ * @param[in]  drv_id      driver id is a unique interrupt handler identifier.
+ *                         It can also be used for driver data.
+ * @return     0 for success, non-zero on failure
+ */
+int metal_irq_register(int irq,
+		       metal_irq_handler irq_handler,
+		       struct metal_device *dev,
+		       void *drv_id);
+
+/**
+ * @brief      Unregister interrupt handler for driver ID and/or device.
  *
- *             If the interrupt handler, device (dev), and driver ID (drv_id)
- *	       are NULL, deregister all handlers corresponding to the interrupt.
+ *             If interrupt handler (hd), driver ID (drv_id) and device (dev)
+ *             are NULL, unregister all handlers for this interrupt.
  *
- *             If the interrupt handler is NULL, but either the device or
- *             the driver ID is not NULL, only deregister the interrupt
- *             handler Which has been registered with the same device and
- *             driver ID.
+ *             If interrupt handler (hd), device (dev) or driver ID (drv_id),
+ *             are not NULL, unregister handlers matching non NULL criterias.
+ *             e.g: when call is made with drv_id and dev non NULL,
+ *             all handlers matching both are unregistered.
+ *
+ *             If interrupt is not found, or other criterias not matching,
+ *             return -ENOENT
  *
  * @param[in]  irq         interrupt id
  * @param[in]  irq_handler interrupt handler
@@ -80,10 +94,10 @@ struct metal_device;
  * @param[in]  drv_id      driver id. It can be used for driver data.
  * @return     0 for success, non-zero on failure
  */
-int metal_irq_register(int irq,
-		       metal_irq_handler irq_handler,
-		       struct metal_device *dev,
-		       void *drv_id);
+int metal_irq_unregister(int irq,
+			metal_irq_handler irq_handler,
+			struct metal_device *dev,
+			void *drv_id);
 
 /**
  * @brief      disable interrupts

--- a/lib/system/freertos/irq.c
+++ b/lib/system/freertos/irq.c
@@ -38,114 +38,212 @@
 #include "metal/sys.h"
 #include "metal/log.h"
 #include "metal/mutex.h"
+#include "metal/list.h"
+#include "metal/utilities.h"
+#include "metal/alloc.h"
 
-
-
-#define MAX_HDS            10           /**< maximum number of
-                                          handlers per IRQ */
-/** IRQ handler descriptor structure */
+/** IRQ handlers descriptor structure */
 struct metal_irq_hddesc {
-        metal_irq_handler hd; /**< irq handler */
-        void *drv_id;         /**< id to identify the driver
-                                 of the irq handler*/
+	metal_irq_handler hd;     /**< irq handler */
+	void *drv_id;             /**< id to identify the driver
+	                               of the irq handler */
+	struct metal_device *dev; /**< device identifier */
+	struct metal_list list;   /**< handler list container */
 };
 
+/** IRQ descriptor structure */
+struct metal_irq_desc {
+	int irq;                      /**< interrupt number */
+	struct metal_irq_hddesc hdls; /**< interrupt handlers */
+	struct metal_list list;       /**< interrupt list container */
+};
+
+/** IRQ state structure */
 struct metal_irqs_state {
-        struct metal_irq_hddesc hds[MAX_IRQS][MAX_HDS]; /**< irqs
-                                                           handlers
-                                                           descriptors */
-        unsigned int intr_enable;
-        metal_mutex_t irq_lock;
+	struct metal_irq_desc hds; /**< interrupt descriptors */
+	unsigned int intr_enable;  /**< interrupt enable */
+	metal_mutex_t irq_lock;    /**< access lock */
 };
 
 static struct metal_irqs_state _irqs;
-
 
 int metal_irq_register(int irq,
                        metal_irq_handler hd,
                        struct metal_device *dev,
                        void *drv_id)
 {
+	struct metal_irq_desc *hdd_p = NULL;
+	struct metal_irq_hddesc *hdl_p;
+	struct metal_list *node;
 	unsigned int irq_flags_save;
-	struct metal_irq_hddesc *hd_desc;
-	int j,i = 0;
-
-	(void)dev;
 
 	if (irq < 0) {
-		metal_log(METAL_LOG_ERROR, "%s: irq %d is less than 0.\n", __func__, irq);
-		return -EINVAL;
-	}
-	if (irq >= MAX_IRQS) {
-		metal_log(METAL_LOG_ERROR,
-				"%s: irq %d is larger than the max supported %d.\n", __func__,
-				irq, MAX_IRQS);
+		metal_log(METAL_LOG_ERROR, "%s: irq %d need to be a positive number\n",
+		          __func__, irq);
 		return -EINVAL;
 	}
 
-	if (hd && !drv_id) {
-		metal_log(METAL_LOG_ERROR, "%s: irq %d drv id cannot be 0.\n", __func__, irq);
+	if ((drv_id == NULL) || (hd == NULL)) {
+		metal_log(METAL_LOG_ERROR, "%s: irq %d need drv_id and hd.\n",
+		          __func__, irq);
 		return -EINVAL;
 	}
 
+	/* Search for irq in list */
 	metal_mutex_acquire(&_irqs.irq_lock);
-	while (i < MAX_HDS) {
-		hd_desc = &_irqs.hds[irq][i];
-		if ((hd_desc->drv_id == drv_id) || (!drv_id && !hd)) {
-			if (hd) {
-				metal_log(METAL_LOG_ERROR, "%s: irq %d has already registered."
-						"Will not register again.\n", __func__, irq);
-				metal_mutex_release(&_irqs.irq_lock);
-				return -EINVAL;
-			} else {
-				/* we are at end of registered hds */
-				if (!hd_desc->drv_id)
-					break;
+	metal_list_for_each(&_irqs.hds.list, node) {
+		hdd_p = metal_container_of(node, struct metal_irq_desc, list);
 
-				/* Make sure there are no hole in the hds */
-				irq_flags_save=metal_irq_save_disable();
-				for (j = i+1; j < MAX_HDS && 0 != _irqs.hds[irq][j].drv_id; j++) {
-					_irqs.hds[irq][j-1] = _irqs.hds[irq][j];
+		if (hdd_p->irq == irq) {
+			struct metal_list *h_node;
+
+			/* Check if drv_id already exist */
+			metal_list_for_each(&hdd_p->hdls.list, h_node) {
+				hdl_p = metal_container_of(h_node, struct metal_irq_hddesc, list);
+
+				/* if drv_id already exist reject */
+				if ((hdl_p->drv_id == drv_id) &&
+					((dev == NULL) || (hdl_p->dev == dev))) {
+					metal_log(METAL_LOG_ERROR, "%s: irq %d already registered."
+							"Will not register again.\n",
+							__func__, irq);
+					metal_mutex_release(&_irqs.irq_lock);
+					return -EINVAL;
 				}
-				hd_desc = &_irqs.hds[irq][j-1];
-				hd_desc->hd = 0;
-				hd_desc->drv_id = 0;
-				metal_irq_restore_enable(irq_flags_save);
-
-				/* If drv_id and hd are null, it will deregister
-				 * all the handlers of the specified IRQ.
-				 * Otherwise only the matching drv_id will deregister.
-				 */
-				if (drv_id)
-					break;
-
-				continue;
 			}
-		} else if (!hd_desc->drv_id && hd) {
-			irq_flags_save=metal_irq_save_disable();
-			hd_desc->drv_id = drv_id;
-			hd_desc->hd = hd;
-			metal_irq_restore_enable(irq_flags_save);
+			/* irq found and drv_id not used, get out of metal_list_for_each */
 			break;
-		} else if (!hd_desc->drv_id) {
-			metal_log(METAL_LOG_ERROR, "%s: irq %d drv id not found.\n", __func__, irq);
-			metal_mutex_release(&_irqs.irq_lock);
-			return -EINVAL;
 		}
-		i++;
 	}
-	metal_mutex_release(&_irqs.irq_lock);
 
-	if (i >= MAX_HDS) {
-		metal_log(METAL_LOG_ERROR, "%s: exceed maximum handlers per IRQ.\n",
-				__func__);
+	/* Either need to add handler to an existing list or to a new one */
+	hdl_p = metal_allocate_memory(sizeof(struct metal_irq_hddesc));
+	if (hdl_p == NULL) {
+		metal_log(METAL_LOG_ERROR,
+		          "%s: irq %d cannot allocate mem for drv_id %d.\n",
+		          __func__, irq, drv_id);
+		metal_mutex_release(&_irqs.irq_lock);
+		return -ENOMEM;
+	}
+	hdl_p->hd = hd;
+	hdl_p->drv_id = drv_id;
+	hdl_p->dev = dev;
+
+	/* interrupt already registered, add handler to existing list*/
+	if ((hdd_p != NULL) && (hdd_p->irq == irq)) {
+		irq_flags_save=metal_irq_save_disable();
+		metal_list_add_tail(&hdd_p->hdls.list, &hdl_p->list);
+		metal_irq_restore_enable(irq_flags_save);
+
+		metal_log(METAL_LOG_DEBUG, "%s: success, irq %d add drv_id %p \n",
+		          __func__, irq, drv_id);
+		metal_mutex_release(&_irqs.irq_lock);
+		return 0;
+	}
+
+	/* interrupt was not already registered, add */
+	hdd_p = metal_allocate_memory(sizeof(struct metal_irq_desc));
+	if (hdd_p == NULL) {
+		metal_log(METAL_LOG_ERROR, "%s: irq %d cannot allocate mem.\n",
+		          __func__, irq);
+		metal_mutex_release(&_irqs.irq_lock);
+		return -ENOMEM;
+	}
+	hdd_p->irq = irq;
+	metal_list_init(&hdd_p->hdls.list);
+	metal_list_add_tail(&hdd_p->hdls.list, &hdl_p->list);
+
+	irq_flags_save=metal_irq_save_disable();
+	metal_list_add_tail(&_irqs.hds.list, &hdd_p->list);
+	metal_irq_restore_enable(irq_flags_save);
+
+	metal_log(METAL_LOG_DEBUG, "%s: success, added irq %d\n", __func__, irq);
+	metal_mutex_release(&_irqs.irq_lock);
+	return 0;
+}
+
+/* helper function for metal_irq_unregister() */
+static void metal_irq_delete_node(struct metal_list **node, void *p_to_free)
+{
+	unsigned int irq_flags_save;
+
+	*node = (*node)->prev;
+	irq_flags_save=metal_irq_save_disable();
+	metal_list_del((*node)->next);
+	metal_irq_restore_enable(irq_flags_save);
+	metal_free_memory(p_to_free);
+}
+
+int metal_irq_unregister(int irq,
+                         metal_irq_handler hd,
+                         struct metal_device *dev,
+                         void *drv_id)
+{
+	struct metal_irq_desc *hdd_p;
+	struct metal_list *node;
+
+	if (irq < 0) {
+		metal_log(METAL_LOG_ERROR, "%s: irq %d need to be a positive number\n",
+		          __func__, irq);
 		return -EINVAL;
 	}
 
-	metal_log(METAL_LOG_DEBUG, "%s: %sregistered IRQ %d\n", __func__,
-			  hd ? "" : "de",	irq);
+	/* Search for irq in list */
+	metal_mutex_acquire(&_irqs.irq_lock);
+	metal_list_for_each(&_irqs.hds.list, node) {
 
-	return 0;
+		hdd_p = metal_container_of(node, struct metal_irq_desc, list);
+
+		if (hdd_p->irq == irq) {
+			struct metal_list *h_node;
+			struct metal_irq_hddesc *hdl_p;
+			unsigned int delete_count = 0;
+
+			metal_log(METAL_LOG_DEBUG, "%s: found irq %d\n", __func__, irq);
+
+			/* Search through handlers */
+			metal_list_for_each(&hdd_p->hdls.list, h_node) {
+				hdl_p = metal_container_of(h_node, struct metal_irq_hddesc, list);
+
+				if (((hd == NULL) || (hdl_p->hd == hd)) &&
+				    ((drv_id == NULL) || (hdl_p->drv_id == drv_id)) &&
+				    ((dev    == NULL) || (hdl_p->dev == dev))) {
+					metal_log(METAL_LOG_DEBUG,
+					          "%s: unregister hd=%p drv_id=%p dev=%p\n",
+						  __func__, hdl_p->hd, hdl_p->drv_id, hdl_p->dev);
+					metal_irq_delete_node(&h_node, hdl_p);
+					delete_count++;
+				}
+			}
+
+			/* we did not find any handler to delete */
+			if (!delete_count) {
+				metal_log(METAL_LOG_DEBUG, "%s: No matching entry\n",
+				          __func__);
+				metal_mutex_release(&_irqs.irq_lock);
+				return -ENOENT;
+
+			}
+
+			/* if interrupt handlers list is empty, unregister interrupt */
+			if (metal_list_is_empty(&hdd_p->hdls.list)) {
+				metal_log(METAL_LOG_DEBUG,
+				          "%s: handlers list empty, unregister interrupt\n",
+					  __func__);
+				metal_irq_delete_node(&node, hdd_p);
+			}
+
+			metal_log(METAL_LOG_DEBUG, "%s: success\n", __func__);
+
+			metal_mutex_release(&_irqs.irq_lock);
+			return 0;
+		}
+	}
+
+	metal_log(METAL_LOG_DEBUG, "%s: No matching IRQ entry\n", __func__);
+
+	metal_mutex_release(&_irqs.irq_lock);
+	return -ENOENT;
 }
 
 unsigned int metal_irq_save_disable(void)
@@ -170,36 +268,50 @@ void metal_irq_restore_enable(unsigned int flags)
 
 void metal_irq_enable(unsigned int vector)
 {
-        sys_irq_enable(vector);
+	sys_irq_enable(vector);
 }
 
 void metal_irq_disable(unsigned int vector)
 {
-        sys_irq_disable(vector);
+	sys_irq_disable(vector);
 }
 
+/**
+ * @brief default handler
+ */
 void metal_irq_isr(unsigned int vector)
 {
-        metal_irq_handler  hd; /**< irq handler */
-        int j;
+	struct metal_list *node;
+	struct metal_irq_desc *hdd_p;
 
-        for(j = 0; j < MAX_HDS; j++) {
-        	hd = _irqs.hds[vector][j].hd;
-        	/* there are no hole in the hds */
-        	if (!hd) break;
-        	hd(vector, _irqs.hds[vector][j].drv_id);
-        }
+	metal_list_for_each(&_irqs.hds.list, node) {
+		hdd_p = metal_container_of(node, struct metal_irq_desc, list);
+
+		if ((unsigned int)hdd_p->irq == vector) {
+			struct metal_list *h_node;
+			struct metal_irq_hddesc *hdl_p;
+
+			metal_list_for_each(&hdd_p->hdls.list, h_node) {
+				hdl_p = metal_container_of(h_node, struct metal_irq_hddesc, list);
+
+				(hdl_p->hd)(vector, hdl_p->drv_id);
+			}
+		}
+	}
 }
 
 int metal_irq_init(void)
 {
-       /* memset(&_irqs, 0, sizeof(_irqs)); */
-
-       metal_mutex_init(&_irqs.irq_lock);
-       return 0;
+	/* list of interrupt having at least one handler registered */
+	metal_list_init(&_irqs.hds.list);
+	/* list of registered handlers for an interrupt */
+	metal_list_init(&_irqs.hds.hdls.list);
+	/* mutex to manage concurrent access to shared irq data */
+	metal_mutex_init(&_irqs.irq_lock);
+	return 0;
 }
 
 void metal_irq_deinit(void) 
 {
-       metal_mutex_deinit(&_irqs.irq_lock);
+	metal_mutex_deinit(&_irqs.irq_lock);
 }

--- a/lib/system/freertos/irq.c
+++ b/lib/system/freertos/irq.c
@@ -61,7 +61,6 @@ struct metal_irq_desc {
 /** IRQ state structure */
 struct metal_irqs_state {
 	struct metal_irq_desc hds; /**< interrupt descriptors */
-	unsigned int intr_enable;  /**< interrupt enable */
 	metal_mutex_t irq_lock;    /**< access lock */
 };
 
@@ -248,11 +247,7 @@ int metal_irq_unregister(int irq,
 
 unsigned int metal_irq_save_disable(void)
 {
-	if (_irqs.intr_enable == 1) {
-		sys_irq_save_disable();
-		_irqs.intr_enable = 0;
-	}
-
+	sys_irq_save_disable();
 	return 0;
 }
 
@@ -260,10 +255,7 @@ void metal_irq_restore_enable(unsigned int flags)
 {
 	(void)flags;
 
-	if (_irqs.intr_enable == 0) {
-		sys_irq_restore_enable();
-		_irqs.intr_enable = 1;
-	}
+	sys_irq_restore_enable();
 }
 
 void metal_irq_enable(unsigned int vector)

--- a/lib/system/freertos/zynq7/sys.h
+++ b/lib/system/freertos/zynq7/sys.h
@@ -48,10 +48,6 @@ extern "C" {
 
 #ifdef METAL_INTERNAL
 
-#if !defined(MAX_IRQS)
-#define MAX_IRQS	((int)XSCUGIC_MAX_NUM_INTR_INPUTS)          /**< maximum number of irqs */
-#endif
-
 static inline void sys_irq_enable(unsigned int vector)
 {
         XScuGic_EnableIntr(XPAR_SCUGIC_0_DIST_BASEADDR, vector);

--- a/lib/system/freertos/zynqmp_a53/sys.h
+++ b/lib/system/freertos/zynqmp_a53/sys.h
@@ -48,10 +48,6 @@ extern "C" {
 
 #ifdef METAL_INTERNAL
 
-#if !defined(MAX_IRQS)
-#define MAX_IRQS	((int)XSCUGIC_MAX_NUM_INTR_INPUTS)          /**< maximum number of irqs */
-#endif
-
 static inline void sys_irq_enable(unsigned int vector)
 {
         XScuGic_EnableIntr(XPAR_SCUGIC_0_DIST_BASEADDR, vector);

--- a/lib/system/freertos/zynqmp_r5/sys.h
+++ b/lib/system/freertos/zynqmp_r5/sys.h
@@ -48,10 +48,6 @@ extern "C" {
 
 #ifdef METAL_INTERNAL
 
-#if !defined(MAX_IRQS)
-#define MAX_IRQS	((int)XSCUGIC_MAX_NUM_INTR_INPUTS)          /**< maximum number of irqs */
-#endif
-
 static inline void sys_irq_enable(unsigned int vector)
 {
         XScuGic_EnableIntr(XPAR_SCUGIC_0_DIST_BASEADDR, vector);

--- a/lib/system/generic/irq.c
+++ b/lib/system/generic/irq.c
@@ -38,113 +38,212 @@
 #include "metal/sys.h"
 #include "metal/log.h"
 #include "metal/mutex.h"
+#include "metal/list.h"
+#include "metal/utilities.h"
+#include "metal/alloc.h"
 
-
-#define MAX_HDS            10           /**< maximum number of
-                                          handlers per IRQ */
-/** IRQ handler descriptor structure */
+/** IRQ handlers descriptor structure */
 struct metal_irq_hddesc {
-        metal_irq_handler hd; /**< irq handler */
-        void *drv_id;         /**< id to identify the driver
-                                 of the irq handler*/
+	metal_irq_handler hd;     /**< irq handler */
+	void *drv_id;             /**< id to identify the driver
+	                               of the irq handler */
+	struct metal_device *dev; /**< device identifier */
+	struct metal_list list;   /**< handler list container */
 };
 
+/** IRQ descriptor structure */
+struct metal_irq_desc {
+	int irq;                      /**< interrupt number */
+	struct metal_irq_hddesc hdls; /**< interrupt handlers */
+	struct metal_list list;       /**< interrupt list container */
+};
+
+/** IRQ state structure */
 struct metal_irqs_state {
-        struct metal_irq_hddesc hds[MAX_IRQS][MAX_HDS]; /**< irqs
-                                                           handlers
-                                                           descriptors */
-        unsigned int intr_enable;
-        metal_mutex_t irq_lock;
+	struct metal_irq_desc hds; /**< interrupt descriptors */
+	unsigned int intr_enable;  /**< interrupt enable */
+	metal_mutex_t irq_lock;    /**< access lock */
 };
 
 static struct metal_irqs_state _irqs;
-
 
 int metal_irq_register(int irq,
                        metal_irq_handler hd,
                        struct metal_device *dev,
                        void *drv_id)
 {
+	struct metal_irq_desc *hdd_p = NULL;
+	struct metal_irq_hddesc *hdl_p;
+	struct metal_list *node;
 	unsigned int irq_flags_save;
-	struct metal_irq_hddesc *hd_desc;
-	int j,i = 0;
-
-	(void)dev;
 
 	if (irq < 0) {
-		metal_log(METAL_LOG_ERROR, "%s: irq %d is less than 0.\n", __func__, irq);
-		return -EINVAL;
-	}
-	if (irq >= MAX_IRQS) {
-		metal_log(METAL_LOG_ERROR,
-				"%s: irq %d is larger than the max supported %d.\n", __func__,
-				irq, MAX_IRQS);
+		metal_log(METAL_LOG_ERROR, "%s: irq %d need to be a positive number\n",
+		          __func__, irq);
 		return -EINVAL;
 	}
 
-	if (hd && !drv_id) {
-		metal_log(METAL_LOG_ERROR, "%s: irq %d drv id cannot be 0.\n", __func__, irq);
+	if ((drv_id == NULL) || (hd == NULL)) {
+		metal_log(METAL_LOG_ERROR, "%s: irq %d need drv_id and hd.\n",
+		          __func__, irq);
 		return -EINVAL;
 	}
 
+	/* Search for irq in list */
 	metal_mutex_acquire(&_irqs.irq_lock);
-	while (i < MAX_HDS) {
-		hd_desc = &_irqs.hds[irq][i];
-		if ((hd_desc->drv_id == drv_id) || (!drv_id && !hd)) {
-			if (hd) {
-				metal_log(METAL_LOG_ERROR, "%s: irq %d has already registered."
-						"Will not register again.\n", __func__, irq);
-				metal_mutex_release(&_irqs.irq_lock);
-				return -EINVAL;
-			} else {
-				/* we are at end of registered hds */
-				if (!hd_desc->drv_id)
-					break;
+	metal_list_for_each(&_irqs.hds.list, node) {
+		hdd_p = metal_container_of(node, struct metal_irq_desc, list);
 
-				/* Make sure there are no hole in the hds */
-				irq_flags_save=metal_irq_save_disable();
-				for (j = i+1; j < MAX_HDS && 0 != _irqs.hds[irq][j].drv_id; j++) {
-					_irqs.hds[irq][j-1] = _irqs.hds[irq][j];
+		if (hdd_p->irq == irq) {
+			struct metal_list *h_node;
+
+			/* Check if drv_id already exist */
+			metal_list_for_each(&hdd_p->hdls.list, h_node) {
+				hdl_p = metal_container_of(h_node, struct metal_irq_hddesc, list);
+
+				/* if drv_id already exist reject */
+				if ((hdl_p->drv_id == drv_id) &&
+					((dev == NULL) || (hdl_p->dev == dev))) {
+					metal_log(METAL_LOG_ERROR, "%s: irq %d already registered."
+							"Will not register again.\n",
+							__func__, irq);
+					metal_mutex_release(&_irqs.irq_lock);
+					return -EINVAL;
 				}
-				hd_desc = &_irqs.hds[irq][j-1];
-				hd_desc->hd = 0;
-				hd_desc->drv_id = 0;
-				metal_irq_restore_enable(irq_flags_save);
-
-				/* If drv_id and hd are null, it will deregister
-				 * all the handlers of the specified IRQ.
-				 * Otherwise only the matching drv_id will deregister.
-				 */
-				if (drv_id)
-					break;
-
-				continue;
 			}
-		} else if (!hd_desc->drv_id && hd) {
-			irq_flags_save=metal_irq_save_disable();
-			hd_desc->drv_id = drv_id;
-			hd_desc->hd = hd;
-			metal_irq_restore_enable(irq_flags_save);
+			/* irq found and drv_id not used, get out of metal_list_for_each */
 			break;
-		} else if (!hd_desc->drv_id) {
-			metal_log(METAL_LOG_ERROR, "%s: irq %d drv id not found.\n", __func__, irq);
-			metal_mutex_release(&_irqs.irq_lock);
-			return -EINVAL;
 		}
-		i++;
 	}
-	metal_mutex_release(&_irqs.irq_lock);
 
-	if (i >= MAX_HDS) {
-		metal_log(METAL_LOG_ERROR, "%s: exceed maximum handlers per IRQ.\n",
-				__func__);
+	/* Either need to add handler to an existing list or to a new one */
+	hdl_p = metal_allocate_memory(sizeof(struct metal_irq_hddesc));
+	if (hdl_p == NULL) {
+		metal_log(METAL_LOG_ERROR,
+		          "%s: irq %d cannot allocate mem for drv_id %d.\n",
+		          __func__, irq, drv_id);
+		metal_mutex_release(&_irqs.irq_lock);
+		return -ENOMEM;
+	}
+	hdl_p->hd = hd;
+	hdl_p->drv_id = drv_id;
+	hdl_p->dev = dev;
+
+	/* interrupt already registered, add handler to existing list*/
+	if ((hdd_p != NULL) && (hdd_p->irq == irq)) {
+		irq_flags_save=metal_irq_save_disable();
+		metal_list_add_tail(&hdd_p->hdls.list, &hdl_p->list);
+		metal_irq_restore_enable(irq_flags_save);
+
+		metal_log(METAL_LOG_DEBUG, "%s: success, irq %d add drv_id %p \n",
+		          __func__, irq, drv_id);
+		metal_mutex_release(&_irqs.irq_lock);
+		return 0;
+	}
+
+	/* interrupt was not already registered, add */
+	hdd_p = metal_allocate_memory(sizeof(struct metal_irq_desc));
+	if (hdd_p == NULL) {
+		metal_log(METAL_LOG_ERROR, "%s: irq %d cannot allocate mem.\n",
+		          __func__, irq);
+		metal_mutex_release(&_irqs.irq_lock);
+		return -ENOMEM;
+	}
+	hdd_p->irq = irq;
+	metal_list_init(&hdd_p->hdls.list);
+	metal_list_add_tail(&hdd_p->hdls.list, &hdl_p->list);
+
+	irq_flags_save=metal_irq_save_disable();
+	metal_list_add_tail(&_irqs.hds.list, &hdd_p->list);
+	metal_irq_restore_enable(irq_flags_save);
+
+	metal_log(METAL_LOG_DEBUG, "%s: success, added irq %d\n", __func__, irq);
+	metal_mutex_release(&_irqs.irq_lock);
+	return 0;
+}
+
+/* helper function for metal_irq_unregister() */
+static void metal_irq_delete_node(struct metal_list **node, void *p_to_free)
+{
+	unsigned int irq_flags_save;
+
+	*node = (*node)->prev;
+	irq_flags_save=metal_irq_save_disable();
+	metal_list_del((*node)->next);
+	metal_irq_restore_enable(irq_flags_save);
+	metal_free_memory(p_to_free);
+}
+
+int metal_irq_unregister(int irq,
+                         metal_irq_handler hd,
+                         struct metal_device *dev,
+                         void *drv_id)
+{
+	struct metal_irq_desc *hdd_p;
+	struct metal_list *node;
+
+	if (irq < 0) {
+		metal_log(METAL_LOG_ERROR, "%s: irq %d need to be a positive number\n",
+		          __func__, irq);
 		return -EINVAL;
 	}
 
-	metal_log(METAL_LOG_DEBUG, "%s: %sregistered IRQ %d\n", __func__,
-			  hd ? "" : "de",	irq);
+	/* Search for irq in list */
+	metal_mutex_acquire(&_irqs.irq_lock);
+	metal_list_for_each(&_irqs.hds.list, node) {
 
-	return 0;
+		hdd_p = metal_container_of(node, struct metal_irq_desc, list);
+
+		if (hdd_p->irq == irq) {
+			struct metal_list *h_node;
+			struct metal_irq_hddesc *hdl_p;
+			unsigned int delete_count = 0;
+
+			metal_log(METAL_LOG_DEBUG, "%s: found irq %d\n", __func__, irq);
+
+			/* Search through handlers */
+			metal_list_for_each(&hdd_p->hdls.list, h_node) {
+				hdl_p = metal_container_of(h_node, struct metal_irq_hddesc, list);
+
+				if (((hd == NULL) || (hdl_p->hd == hd)) &&
+				    ((drv_id == NULL) || (hdl_p->drv_id == drv_id)) &&
+				    ((dev == NULL) || (hdl_p->dev == dev))) {
+					metal_log(METAL_LOG_DEBUG,
+					          "%s: unregister hd=%p drv_id=%p dev=%p\n",
+						  __func__, hdl_p->hd, hdl_p->drv_id, hdl_p->dev);
+					metal_irq_delete_node(&h_node, hdl_p);
+					delete_count++;
+				}
+			}
+
+			/* we did not find any handler to delete */
+			if (!delete_count) {
+				metal_log(METAL_LOG_DEBUG, "%s: No matching entry\n",
+				          __func__);
+				metal_mutex_release(&_irqs.irq_lock);
+				return -ENOENT;
+
+			}
+
+			/* if interrupt handlers list is empty, unregister interrupt */
+			if (metal_list_is_empty(&hdd_p->hdls.list)) {
+				metal_log(METAL_LOG_DEBUG,
+				          "%s: handlers list empty, unregister interrupt\n",
+					  __func__);
+				metal_irq_delete_node(&node, hdd_p);
+			}
+
+			metal_log(METAL_LOG_DEBUG, "%s: success\n", __func__);
+
+			metal_mutex_release(&_irqs.irq_lock);
+			return 0;
+		}
+	}
+
+	metal_log(METAL_LOG_DEBUG, "%s: No matching IRQ entry\n", __func__);
+
+	metal_mutex_release(&_irqs.irq_lock);
+	return -ENOENT;
 }
 
 unsigned int metal_irq_save_disable(void)
@@ -182,26 +281,37 @@ void metal_irq_disable(unsigned int vector)
  */
 void metal_irq_isr(unsigned int vector)
 {
-        metal_irq_handler  hd; /**< irq handler */
-        int j;
+	struct metal_list *node;
+	struct metal_irq_desc *hdd_p;
 
-        for(j = 0; j < MAX_HDS; j++) {
-        	hd = _irqs.hds[vector][j].hd;
-        	/* there are no hole in the hds */
-        	if (!hd) break;
-        	hd(vector, _irqs.hds[vector][j].drv_id);
-        }
+	metal_list_for_each(&_irqs.hds.list, node) {
+		hdd_p = metal_container_of(node, struct metal_irq_desc, list);
+
+		if ((unsigned int)hdd_p->irq == vector) {
+			struct metal_list *h_node;
+			struct metal_irq_hddesc *hdl_p;
+
+			metal_list_for_each(&hdd_p->hdls.list, h_node) {
+				hdl_p = metal_container_of(h_node, struct metal_irq_hddesc, list);
+
+				(hdl_p->hd)(vector, hdl_p->drv_id);
+			}
+		}
+	}
 }
 
 int metal_irq_init(void)
 {
-       /* memset(&_irqs, 0, sizeof(_irqs)); */
-
-       metal_mutex_init(&_irqs.irq_lock);
-       return 0;
+	/* list of interrupt having at least one handler registered */
+	metal_list_init(&_irqs.hds.list);
+	/* list of registered handlers for an interrupt */
+	metal_list_init(&_irqs.hds.hdls.list);
+	/* mutex to manage concurrent access to shared irq data */
+	metal_mutex_init(&_irqs.irq_lock);
+	return 0;
 }
 
 void metal_irq_deinit(void) 
 {
-       metal_mutex_deinit(&_irqs.irq_lock);
+	metal_mutex_deinit(&_irqs.irq_lock);
 }

--- a/lib/system/generic/irq.c
+++ b/lib/system/generic/irq.c
@@ -61,7 +61,6 @@ struct metal_irq_desc {
 /** IRQ state structure */
 struct metal_irqs_state {
 	struct metal_irq_desc hds; /**< interrupt descriptors */
-	unsigned int intr_enable;  /**< interrupt enable */
 	metal_mutex_t irq_lock;    /**< access lock */
 };
 
@@ -248,11 +247,7 @@ int metal_irq_unregister(int irq,
 
 unsigned int metal_irq_save_disable(void)
 {
-	if (_irqs.intr_enable == 1) {
-		sys_irq_save_disable();
-		_irqs.intr_enable = 0;
-	}
-
+	sys_irq_save_disable();
 	return 0;
 }
 
@@ -260,20 +255,17 @@ void metal_irq_restore_enable(unsigned int flags)
 {
 	(void)flags;
 
-	if (_irqs.intr_enable == 0) {
-		sys_irq_restore_enable();
-		_irqs.intr_enable = 1;
-	}
+	sys_irq_restore_enable();
 }
 
 void metal_irq_enable(unsigned int vector)
 {
-        sys_irq_enable(vector);
+	sys_irq_enable(vector);
 }
 
 void metal_irq_disable(unsigned int vector)
 {
-        sys_irq_disable(vector);
+	sys_irq_disable(vector);
 }
 
 /**

--- a/lib/system/generic/zynq7/sys.h
+++ b/lib/system/generic/zynq7/sys.h
@@ -48,10 +48,6 @@ extern "C" {
 
 #ifdef METAL_INTERNAL
 
-#if !defined(MAX_IRQS)
-#define MAX_IRQS	((int)XSCUGIC_MAX_NUM_INTR_INPUTS)          /**< maximum number of irqs */
-#endif
-
 static inline void sys_irq_enable(unsigned int vector)
 {
         XScuGic_EnableIntr(XPAR_SCUGIC_0_DIST_BASEADDR, vector);

--- a/lib/system/generic/zynqmp_a53/sys.h
+++ b/lib/system/generic/zynqmp_a53/sys.h
@@ -48,10 +48,6 @@ extern "C" {
 
 #ifdef METAL_INTERNAL
 
-#if !defined(MAX_IRQS)
-#define MAX_IRQS	((int)XSCUGIC_MAX_NUM_INTR_INPUTS)          /**< maximum number of irqs */
-#endif
-
 static inline void sys_irq_enable(unsigned int vector)
 {
         XScuGic_EnableIntr(XPAR_SCUGIC_0_DIST_BASEADDR, vector);

--- a/lib/system/generic/zynqmp_r5/sys.h
+++ b/lib/system/generic/zynqmp_r5/sys.h
@@ -48,10 +48,6 @@ extern "C" {
 
 #ifdef METAL_INTERNAL
 
-#if !defined(MAX_IRQS)
-#define MAX_IRQS	((int)XSCUGIC_MAX_NUM_INTR_INPUTS)          /**< maximum number of irqs */
-#endif
-
 static inline void sys_irq_enable(unsigned int vector)
 {
         XScuGic_EnableIntr(XPAR_SCUGIC_0_DIST_BASEADDR, vector);

--- a/lib/system/linux/device.c
+++ b/lib/system/linux/device.c
@@ -284,7 +284,10 @@ static void metal_uio_dev_close(struct linux_bus *lbus,
 	(void)lbus;
 
 	if ((intptr_t)ldev->device.irq_info >= 0)
-		metal_irq_register(ldev->fd, NULL, NULL, NULL);
+		/* Normally this call would not be needed, and is added as precaution.
+		   Also for uio there is only 1 interrupt associated to the fd/device,
+		   we therefore do not need to specify a particular device */
+		metal_irq_unregister(ldev->fd, NULL, NULL, NULL);
 
 	if (ldev->override) {
 		sysfs_write_attribute(ldev->override, "", 1);
@@ -305,7 +308,7 @@ static void metal_uio_dev_irq_ack(struct linux_bus *lbus,
 {
 	(void)lbus;
 	(void)irq;
-	unsigned int irq_info = 1;
+	int irq_info = 1;
 	unsigned int val;
 	int ret;
 

--- a/lib/system/linux/irq.c
+++ b/lib/system/linux/irq.c
@@ -305,13 +305,13 @@ static void *metal_linux_irq_handling(void *args)
 		pfds_total = j;
 		for (i = 0; i < pfds_total; i++) {
 			if ( (pfds[i].fd == _irqs.irq_reg_fd) &&
-			     (pfds[i].revents & (POLLIN | POLLERR))) {
+			     (pfds[i].revents & (POLLIN | POLLRDNORM))) {
 				/* IRQ registration change notification */
 				if (read(pfds[i].fd, (void*)&val, sizeof(uint64_t)) < 0)
 					metal_log(METAL_LOG_ERROR,
 					"%s, read irq fd %d failed.\n",
 					__func__, pfds[i].fd);
-			} else if ((pfds[i].revents & (POLLIN | POLLERR))) {
+			} else if ((pfds[i].revents & (POLLIN | POLLRDNORM))) {
 				irq_handled = 0;
 				dev = NULL;
 				for(j = 0, hddec = &_irqs.hds[pfds[i].fd][0];

--- a/test/system/freertos/irq.c
+++ b/test/system/freertos/irq.c
@@ -39,8 +39,8 @@
 #include "metal/irq.h"
 #include "metal/log.h"
 #include "metal/sys.h"
-
-#define MAX_HDS  10
+#include "metal/list.h"
+#include "metal/utilities.h"
 
 
 int irq_handler(int irq, void *priv)
@@ -54,49 +54,169 @@ int irq_handler(int irq, void *priv)
 
 static int irq(void)
 {
-	long i, j; 
 	int rc = 0, flags_1, flags_2;
+	char *err_msg="";
 	enum metal_log_level mll= metal_get_log_level();
 
-
+	/* Do not show LOG_ERROR or LOG_DEBUG for expected fail case */
 	metal_set_log_level(METAL_LOG_CRITICAL);
 
-	/* go over the max to force an error */
-	for (i=-1; i <=  MAX_IRQS+3; i++) {
-		for (j=0; j <= MAX_HDS+3; j++) {
-			rc = metal_irq_register(i, irq_handler, 0, (void *)j);
-
-			/* check boundaries and drv_id ==0 while handler is not null */
-			if ((rc &&
-					((i >= MAX_IRQS) || (j >= (MAX_HDS+1))  ||
-					 (i < 0 ) || (j <= 0))
-				) ||
-				(!rc &&
-					(i < MAX_IRQS) && (j < (MAX_HDS+1)) &&
-					(i >= 0) && (j > 0)
-				))
-				continue;
-
-			metal_set_log_level(mll);
-			metal_log(METAL_LOG_DEBUG, "register irq %d fail hd %d\n", i, j);
-			return rc ? rc : -EINVAL;
-		}
+	rc = metal_irq_register(1, irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "register irq 1 fail drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(2, irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "register irq 2 fail drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(2, irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 2 fail drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_register(3, irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "register irq 3 fail drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(4, irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "register irq 4 fail drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(4, irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 4 fail drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_register(1, irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 1 fail drv_id 2\n";
+		goto out;
 	}
 
-	/* delete all handlers for IRQ #1 */
-	rc = metal_irq_register(1, 0, 0, (void *)0);
+	rc = metal_irq_unregister(1, 0, 0, (void *)0);
 	if (rc) {
-		metal_set_log_level(mll);
-		metal_log(METAL_LOG_DEBUG, "deregister irq 1 all handlers\n");
-		return rc;
+		err_msg = "unregister irq 1 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(1, 0, 0, (void *)0);
+	if (!rc) {
+		err_msg = "unregister irq 1 fail expected\n";
+		goto out;
 	}
 
-	/* delete only one handler IRQ */
-	rc = metal_irq_register(2, 0, 0, (void *)3);
+	rc = metal_irq_unregister(2, 0, 0, (void *)2);
 	if (rc) {
-		metal_set_log_level(mll);
-		metal_log(METAL_LOG_DEBUG, "deregister irq 2 hd %d\n", 3);
-		return rc;
+		err_msg = "unregister irq 2 drv_id 2 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(2, 0, 0, (void *)2);
+	if (!rc) {
+		err_msg = "unregister irq 2 drv_id 2 fail expected\n";
+		goto out;
+	}
+	rc = metal_irq_register(2, irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 2 fail drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_unregister(2, 0, 0, (void *)1);
+	if (rc) {
+		err_msg = "unregister irq 2 drv_id 1 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(2, 0, 0, (void *)2);
+	if (rc) {
+		err_msg = "unregister irq 2 drv_id 2 failed \n";
+		goto out;
+	}
+
+	rc = metal_irq_register(3, irq_handler, 0, (void *)1);
+	if (!rc) {
+		err_msg = "register irq 3 drv_id 1 overwrite fail expected\n";
+		goto out;
+	}
+	rc = metal_irq_register(3, irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 3 fail drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_unregister(3, irq_handler+1, 0, (void *)0);
+	if (!rc) {
+		err_msg = "unregister irq 3 match handler fail expected\n";
+		goto out;
+	}
+	rc = metal_irq_unregister(3, irq_handler, 0, (void *)0);
+	if (rc) {
+		err_msg = "unregister irq 3 match handler failed \n";
+		goto out;
+	}
+
+	rc = metal_irq_unregister(4, irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "unregister irq 4 match handler and drv_id 2 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(4, irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "unregister irq 4 match handler and drv_id 1 failed \n";
+		goto out;
+	}
+
+	rc = metal_irq_register(5, irq_handler, (void *)10, (void *)1);
+	if (rc) {
+		err_msg = "register irq 5 fail dev 10 drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(5, irq_handler, (void *)20, (void *)2);
+	if (rc) {
+		err_msg = "register irq 5 fail dev 20 drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_register(5, irq_handler, (void *)10, (void *)3);
+	if (rc) {
+		err_msg = "register irq 5 fail dev 10 drv_id 3\n";
+		goto out;
+	}
+	rc = metal_irq_register(5, irq_handler, 0, (void *)4);
+	if (rc) {
+		err_msg = "register irq 5 fail drv_id 4\n";
+		goto out;
+	}
+	rc = metal_irq_register(5, irq_handler, (void *)10, (void *)5);
+	if (rc) {
+		err_msg = "register irq 5 fail dev 10 drv_id 5\n";
+		goto out;
+	}
+
+	rc = metal_irq_unregister(5, irq_handler, (void *)10, (void *)3);
+	if (rc) {
+		err_msg = "unregister irq 5 match handle, dev 10 and drv_id 3 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(5, 0, 0, (void *)4);
+	if (rc) {
+		err_msg = "unregister irq 5 drv_id 4 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(5, 0, (void *)10, 0);
+	if (rc) {
+		err_msg = "unregister irq 5 dev 10 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(5, 0, (void *)20, (void *)2);
+	if (rc) {
+		err_msg = "unregister irq 5 match dev 20 and drv_id 2 failed \n";
+		goto out;
+	}
+
+	rc = metal_irq_register(-1, irq_handler, 0, (void *)1);
+	if (!rc) {
+		err_msg = "register irq -1 should have failed\n";
+		goto out;
 	}
 
 	/* global interrupt disable/enable normal behavior */
@@ -109,7 +229,13 @@ static int irq(void)
 	metal_irq_restore_enable(flags_2);
 	metal_irq_restore_enable(flags_1);
 
+	rc = 0;
+
+out:
 	metal_set_log_level(mll);
+	if ((err_msg[0] != '\0') && (!rc))
+		rc = -EINVAL;
+	if (rc) metal_log(METAL_LOG_ERROR, "%s", err_msg);
 	return rc;
 }
 

--- a/test/system/generic/irq.c
+++ b/test/system/generic/irq.c
@@ -39,8 +39,8 @@
 #include "metal/irq.h"
 #include "metal/log.h"
 #include "metal/sys.h"
-
-#define MAX_HDS  10
+#include "metal/list.h"
+#include "metal/utilities.h"
 
 
 int irq_handler(int irq, void *priv)
@@ -54,49 +54,169 @@ int irq_handler(int irq, void *priv)
 
 static int irq(void)
 {
-	long i, j;
 	int rc = 0, flags_1, flags_2;
+	char *err_msg="";
 	enum metal_log_level mll= metal_get_log_level();
 
-
+	/* Do not show LOG_ERROR or LOG_DEBUG for expected fail case */
 	metal_set_log_level(METAL_LOG_CRITICAL);
 
-	/* go over the max to force an error */
-	for (i=-1; i <=  MAX_IRQS+3; i++) {
-		for (j=0; j <= MAX_HDS+3; j++) {
-			rc = metal_irq_register(i, irq_handler, 0, (void *)j);
-
-			/* check boundaries and drv_id ==0 while handler is not null */
-			if ((rc &&
-					((i >= MAX_IRQS) || (j >= (MAX_HDS+1))  ||
-					 (i < 0 ) || (j <= 0))
-				) ||
-				(!rc &&
-					(i < MAX_IRQS) && (j < (MAX_HDS+1)) &&
-					(i >= 0) && (j > 0)
-				))
-				continue;
-
-			metal_set_log_level(mll);
-			metal_log(METAL_LOG_DEBUG, "register irq %d fail hd %d\n", i, j);
-			return rc ? rc : -EINVAL;
-		}
+	rc = metal_irq_register(1, irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "register irq 1 fail drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(2, irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "register irq 2 fail drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(2, irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 2 fail drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_register(3, irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "register irq 3 fail drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(4, irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "register irq 4 fail drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(4, irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 4 fail drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_register(1, irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 1 fail drv_id 2\n";
+		goto out;
 	}
 
-	/* delete all handlers for IRQ #1 */
-	rc = metal_irq_register(1, 0, 0, (void *)0);
+	rc = metal_irq_unregister(1, 0, 0, (void *)0);
 	if (rc) {
-		metal_set_log_level(mll);
-		metal_log(METAL_LOG_DEBUG, "deregister irq 1 all handlers\n");
-		return rc;
+		err_msg = "unregister irq 1 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(1, 0, 0, (void *)0);
+	if (!rc) {
+		err_msg = "unregister irq 1 fail expected\n";
+		goto out;
 	}
 
-	/* delete only one handler IRQ */
-	rc = metal_irq_register(2, 0, 0, (void *)3);
+	rc = metal_irq_unregister(2, 0, 0, (void *)2);
 	if (rc) {
-		metal_set_log_level(mll);
-		metal_log(METAL_LOG_DEBUG, "deregister irq 2 hd %d\n", 3);
-		return rc;
+		err_msg = "unregister irq 2 drv_id 2 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(2, 0, 0, (void *)2);
+	if (!rc) {
+		err_msg = "unregister irq 2 drv_id 2 fail expected\n";
+		goto out;
+	}
+	rc = metal_irq_register(2, irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 2 fail drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_unregister(2, 0, 0, (void *)1);
+	if (rc) {
+		err_msg = "unregister irq 2 drv_id 1 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(2, 0, 0, (void *)2);
+	if (rc) {
+		err_msg = "unregister irq 2 drv_id 2 failed \n";
+		goto out;
+	}
+
+	rc = metal_irq_register(3, irq_handler, 0, (void *)1);
+	if (!rc) {
+		err_msg = "register irq 3 drv_id 1 overwrite fail expected\n";
+		goto out;
+	}
+	rc = metal_irq_register(3, irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 3 fail drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_unregister(3, irq_handler+1, 0, (void *)0);
+	if (!rc) {
+		err_msg = "unregister irq 3 match handler fail expected\n";
+		goto out;
+	}
+	rc = metal_irq_unregister(3, irq_handler, 0, (void *)0);
+	if (rc) {
+		err_msg = "unregister irq 3 match handler failed \n";
+		goto out;
+	}
+
+	rc = metal_irq_unregister(4, irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "unregister irq 4 match handler and drv_id 2 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(4, irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "unregister irq 4 match handler and drv_id 1 failed \n";
+		goto out;
+	}
+
+	rc = metal_irq_register(5, irq_handler, (void *)10, (void *)1);
+	if (rc) {
+		err_msg = "register irq 5 fail dev 10 drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(5, irq_handler, (void *)20, (void *)2);
+	if (rc) {
+		err_msg = "register irq 5 fail dev 20 drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_register(5, irq_handler, (void *)10, (void *)3);
+	if (rc) {
+		err_msg = "register irq 5 fail dev 10 drv_id 3\n";
+		goto out;
+	}
+	rc = metal_irq_register(5, irq_handler, 0, (void *)4);
+	if (rc) {
+		err_msg = "register irq 5 fail drv_id 4\n";
+		goto out;
+	}
+	rc = metal_irq_register(5, irq_handler, (void *)10, (void *)5);
+	if (rc) {
+		err_msg = "register irq 5 fail dev 10 drv_id 5\n";
+		goto out;
+	}
+
+	rc = metal_irq_unregister(5, irq_handler, (void *)10, (void *)3);
+	if (rc) {
+		err_msg = "unregister irq 5 match handle, dev 10 and drv_id 3 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(5, 0, 0, (void *)4);
+	if (rc) {
+		err_msg = "unregister irq 5 drv_id 4 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(5, 0, (void *)10, 0);
+	if (rc) {
+		err_msg = "unregister irq 5 dev 10 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(5, 0, (void *)20, (void *)2);
+	if (rc) {
+		err_msg = "unregister irq 5 match dev 20 and drv_id 2 failed \n";
+		goto out;
+	}
+
+	rc = metal_irq_register(-1, irq_handler, 0, (void *)1);
+	if (!rc) {
+		err_msg = "register irq -1 should have failed\n";
+		goto out;
 	}
 
 	/* global interrupt disable/enable normal behavior */
@@ -109,7 +229,13 @@ static int irq(void)
 	metal_irq_restore_enable(flags_2);
 	metal_irq_restore_enable(flags_1);
 
+	rc = 0;
+
+out:
 	metal_set_log_level(mll);
+	if ((err_msg[0] != '\0') && (!rc))
+		rc = -EINVAL;
+	if (rc) metal_log(METAL_LOG_ERROR, "%s", err_msg);
 	return rc;
 }
 

--- a/test/system/linux/CMakeLists.txt
+++ b/test/system/linux/CMakeLists.txt
@@ -6,6 +6,7 @@ collect (PROJECT_LIB_TESTS condition.c)
 collect (PROJECT_LIB_TESTS threads.c)
 collect (PROJECT_LIB_TESTS spinlock.c)
 collect (PROJECT_LIB_TESTS alloc.c)
+collect (PROJECT_LIB_TESTS irq.c)
 
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_MACHINE})
   add_subdirectory(${PROJECT_MACHINE})

--- a/test/system/linux/irq.c
+++ b/test/system/linux/irq.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2016, Xilinx Inc. and Contributors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/eventfd.h>
+
+/* We need to find the internal MAX_IRQS limit */
+/* Could be retrieved from platform specific files in the future */
+#define METAL_INTERNAL
+
+#include "metal-test.h"
+#include "metal/irq.h"
+#include "metal/log.h"
+#include "metal/sys.h"
+#include "metal/list.h"
+#include "metal/utilities.h"
+
+
+int irq_handler(int irq, void *priv)
+{
+	(void)irq;
+	(void)priv;
+
+	return 0;
+}
+
+
+static int irq(void)
+{
+	int rc = 0;
+	char *err_msg="";
+	enum metal_log_level mll= metal_get_log_level();
+	int i, tst_irq[6];
+
+	/* Do not show LOG_ERROR or LOG_DEBUG for expected fail case */
+	metal_set_log_level(METAL_LOG_CRITICAL);
+
+	for (i=1; i < 6; i++) {
+		/* we only want to test the lib API, so create 'virtual' IRQs */
+		tst_irq[i] = eventfd(0,0);
+		metal_log(METAL_LOG_DEBUG, "%s: irq %d associated with fd %d\n", __func__, i, tst_irq[i]);
+	}
+
+	rc = metal_irq_register(tst_irq[1], irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "register irq 1 fail drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(tst_irq[2], irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "register irq 2 fail drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(tst_irq[2], irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 2 fail drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_register(tst_irq[3], irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "register irq 3 fail drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(tst_irq[4], irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "register irq 4 fail drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(tst_irq[4], irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 4 fail drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_register(tst_irq[1], irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 1 fail drv_id 2\n";
+		goto out;
+	}
+
+	rc = metal_irq_unregister(tst_irq[1], 0, 0, (void *)0);
+	if (rc) {
+		err_msg = "unregister irq 1 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(tst_irq[1], 0, 0, (void *)0);
+	if (!rc) {
+		err_msg = "unregister irq 1 success but fail expected\n";
+		goto out;
+	}
+
+	rc = metal_irq_unregister(tst_irq[2], 0, 0, (void *)2);
+	if (rc) {
+		err_msg = "unregister irq 2 drv_id 2 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(tst_irq[2], 0, 0, (void *)2);
+	if (!rc) {
+		err_msg = "unregister irq 2 drv_id 2 success but fail expected\n";
+		goto out;
+	}
+	rc = metal_irq_register(tst_irq[2], irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 2 fail drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_unregister(tst_irq[2], 0, 0, (void *)1);
+	if (rc) {
+		err_msg = "unregister irq 2 drv_id 1 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(tst_irq[2], 0, 0, (void *)2);
+	if (rc) {
+		err_msg = "unregister irq 2 drv_id 2 failed \n";
+		goto out;
+	}
+
+	rc = metal_irq_register(tst_irq[3], irq_handler, 0, (void *)1);
+	if (!rc) {
+		err_msg = "register irq 3 drv_id 1 overwrite fail expected\n";
+		goto out;
+	}
+	rc = metal_irq_register(tst_irq[3], irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "register irq 3 fail drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_unregister(tst_irq[3], irq_handler+1, 0, (void *)0);
+	if (!rc) {
+		err_msg = "unregister irq 3 match handler success but fail expected\n";
+		goto out;
+	}
+	rc = metal_irq_unregister(tst_irq[3], irq_handler, 0, (void *)0);
+	if (rc) {
+		err_msg = "unregister irq 3 match handler failed \n";
+		goto out;
+	}
+
+	rc = metal_irq_unregister(tst_irq[4], irq_handler, 0, (void *)2);
+	if (rc) {
+		err_msg = "unregister irq 4 match handler and drv_id 2 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(tst_irq[4], irq_handler, 0, (void *)1);
+	if (rc) {
+		err_msg = "unregister irq 4 match handler and drv_id 1 failed \n";
+		goto out;
+	}
+
+	rc = metal_irq_register(tst_irq[5], irq_handler, (void *)10, (void *)1);
+	if (rc) {
+		err_msg = "register irq 5 fail dev 10 drv_id 1\n";
+		goto out;
+	}
+	rc = metal_irq_register(tst_irq[5], irq_handler, (void *)20, (void *)2);
+	if (rc) {
+		err_msg = "register irq 5 fail dev 20 drv_id 2\n";
+		goto out;
+	}
+	rc = metal_irq_register(tst_irq[5], irq_handler, (void *)10, (void *)3);
+	if (rc) {
+		err_msg = "register irq 5 fail dev 10 drv_id 3\n";
+		goto out;
+	}
+	rc = metal_irq_register(tst_irq[5], irq_handler, 0, (void *)4);
+	if (rc) {
+		err_msg = "register irq 5 fail drv_id 4\n";
+		goto out;
+	}
+	rc = metal_irq_register(tst_irq[5], irq_handler, (void *)10, (void *)5);
+	if (rc) {
+		err_msg = "register irq 5 fail dev 10 drv_id 5\n";
+		goto out;
+	}
+
+	rc = metal_irq_unregister(tst_irq[5], irq_handler, (void *)10, (void *)3);
+	if (rc) {
+		err_msg = "unregister irq 5 match handle, dev 10 and drv_id 3 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(tst_irq[5], 0, 0, (void *)4);
+	if (rc) {
+		err_msg = "unregister irq 5 drv_id 4 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(tst_irq[5], 0, (void *)10, 0);
+	if (rc) {
+		err_msg = "unregister irq 5 dev 10 failed \n";
+		goto out;
+	}
+	rc = metal_irq_unregister(tst_irq[5], 0, (void *)20, (void *)2);
+	if (rc) {
+		err_msg = "unregister irq 5 match dev 20 and drv_id 2 failed \n";
+		goto out;
+	}
+
+	rc = 0;
+
+out:
+	for (i=1; i < 6; i++) {
+		close(tst_irq[i]);
+	}
+	metal_set_log_level(mll);
+	if ((err_msg[0] != '\0') && (!rc))
+		rc = -EINVAL;
+	if (rc) metal_log(METAL_LOG_ERROR, "%s", err_msg);
+	return rc;
+}
+
+METAL_ADD_TEST(irq);


### PR DESCRIPTION
Rework of libmetal IRQ API:
 -Separate original and single metal_irq_register() into two independent functions metal_irq_register() and metal_irq_unregister().
 -Change Baremetal and FreeRTOS implementation to replace irq LUT and handler array with dynamically allocated containers.
 -Process optional device parameter for IRQ registration with Baremetal and FreeRTOS implementation.
 -Change Linux irq handling to check poll()'s revents POLLIN|POLLRDNORM instead of POLLIN|POLLERR
 -Improve irq unit tests to use new metal_irq_unregister() and add more coverage, also add Linux coverage.
 -Remove unneedeed irq_enable flag in generic and FreeRTOS irq lib
 -Change Linux implementation to replace irq handler array with dynamically allocated container.