### PR TITLE
log: fix c++ invalid conversion compilation error

### DIFF
--- a/lib/log.h
+++ b/lib/log.h
@@ -102,9 +102,9 @@ extern void metal_default_log_handler(enum metal_log_level level,
  * @param	...	Format string and arguments.
  */
 #define metal_log(level, ...)						       \
-	(void)((level <= _metal.common.log_level && _metal.common.log_handler) \
-	       ? _metal.common.log_handler(level, __VA_ARGS__)		       \
-	       : 0)
+	((level <= _metal.common.log_level && _metal.common.log_handler) \
+	       ? (void)_metal.common.log_handler(level, __VA_ARGS__)	       \
+	       : (void)0)
 
 /** @} */
 


### PR DESCRIPTION
fix c++ invalid conversion error in metal_log() definition.

Signed-off-by: Wendy Liang <jliang@xilinx.com>