### PR TITLE
Fix sys irq save disable

### DIFF
--- a/lib/system/freertos/zynq7/sys.c
+++ b/lib/system/freertos/zynq7/sys.c
@@ -51,6 +51,7 @@
 /* Mask off lower bits of addr */
 #define     ARM_AR_MEM_TTB_SECT_SIZE_MASK          (~(ARM_AR_MEM_TTB_SECT_SIZE-1UL))
 
+/* default value setting for disabling interrupts */
 static unsigned int int_old_val = XIL_EXCEPTION_ALL;
 
 void sys_irq_restore_enable(void)
@@ -60,13 +61,10 @@ void sys_irq_restore_enable(void)
 
 void sys_irq_save_disable(void)
 {
-	unsigned int value = 0;
+	int_old_val = mfcpsr() & XIL_EXCEPTION_ALL;
 
-	value = mfcpsr() & XIL_EXCEPTION_ALL;
-
-	if (value != int_old_val) {
+	if (XIL_EXCEPTION_ALL != int_old_val) {
 		Xil_ExceptionDisableMask(XIL_EXCEPTION_ALL);
-		int_old_val = value;
 	}
 }
 

--- a/lib/system/freertos/zynqmp_a53/sys.c
+++ b/lib/system/freertos/zynqmp_a53/sys.c
@@ -45,8 +45,7 @@
 #define MB (1024 * 1024UL)
 #define GB (1024 * 1024 * 1024UL)
 
-
-/* application code would have enabled IRQ initially */
+/* default value setting for disabling interrupts */
 static unsigned int int_old_val = XIL_EXCEPTION_ALL;
 
 void sys_irq_restore_enable(void)
@@ -56,13 +55,10 @@ void sys_irq_restore_enable(void)
 
 void sys_irq_save_disable(void)
 {
-	unsigned int value = 0;
+	int_old_val = mfcpsr() & XIL_EXCEPTION_ALL;
 
-	value = mfcpsr() & XIL_EXCEPTION_ALL;
-
-	if (value != int_old_val) {
+	if (XIL_EXCEPTION_ALL != int_old_val) {
 		Xil_ExceptionDisableMask(XIL_EXCEPTION_ALL);
-		int_old_val = value;
 	}
 }
 

--- a/lib/system/freertos/zynqmp_r5/sys.c
+++ b/lib/system/freertos/zynqmp_r5/sys.c
@@ -45,7 +45,7 @@
 
 #define MPU_REGION_SIZE_MIN 0x20
 
-/* application code would have enabled IRQ initially */
+/* default value setting for disabling interrupts */
 static unsigned int int_old_val = XIL_EXCEPTION_ALL;
 
 void sys_irq_restore_enable(void)
@@ -55,13 +55,10 @@ void sys_irq_restore_enable(void)
 
 void sys_irq_save_disable(void)
 {
-	unsigned int value = 0;
+	int_old_val = mfcpsr() & XIL_EXCEPTION_ALL;
 
-	value = mfcpsr() & XIL_EXCEPTION_ALL;
-
-	if (value != int_old_val) {
+	if (XIL_EXCEPTION_ALL != int_old_val) {
 		Xil_ExceptionDisableMask(XIL_EXCEPTION_ALL);
-		int_old_val = value;
 	}
 }
 

--- a/lib/system/generic/zynq7/sys.c
+++ b/lib/system/generic/zynq7/sys.c
@@ -48,6 +48,7 @@
 /* Mask off lower bits of addr */
 #define     ARM_AR_MEM_TTB_SECT_SIZE_MASK          (~(ARM_AR_MEM_TTB_SECT_SIZE-1UL))
 
+/* default value setting for disabling interrupts */
 static unsigned int int_old_val = XIL_EXCEPTION_ALL;
 
 void sys_irq_restore_enable(void)
@@ -57,13 +58,10 @@ void sys_irq_restore_enable(void)
 
 void sys_irq_save_disable(void)
 {
-	unsigned int value = 0;
+	int_old_val = mfcpsr() & XIL_EXCEPTION_ALL;
 
-	value = mfcpsr() & XIL_EXCEPTION_ALL;
-
-	if (value != int_old_val) {
+	if (XIL_EXCEPTION_ALL != int_old_val) {
 		Xil_ExceptionDisableMask(XIL_EXCEPTION_ALL);
-		int_old_val = value;
 	}
 }
 

--- a/lib/system/generic/zynqmp_a53/sys.c
+++ b/lib/system/generic/zynqmp_a53/sys.c
@@ -45,8 +45,7 @@
 #define MB (1024 * 1024UL)
 #define GB (1024 * 1024 * 1024UL)
 
-
-/* application code would have enabled IRQ initially */
+/* default value setting for disabling interrupts */
 static unsigned int int_old_val = XIL_EXCEPTION_ALL;
 
 void sys_irq_restore_enable(void)
@@ -56,13 +55,10 @@ void sys_irq_restore_enable(void)
 
 void sys_irq_save_disable(void)
 {
-	unsigned int value = 0;
+	int_old_val = mfcpsr() & XIL_EXCEPTION_ALL;
 
-	value = mfcpsr() & XIL_EXCEPTION_ALL;
-
-	if (value != int_old_val) {
+	if (XIL_EXCEPTION_ALL != int_old_val) {
 		Xil_ExceptionDisableMask(XIL_EXCEPTION_ALL);
-		int_old_val = value;
 	}
 }
 

--- a/lib/system/generic/zynqmp_r5/sys.c
+++ b/lib/system/generic/zynqmp_r5/sys.c
@@ -45,7 +45,7 @@
 
 #define MPU_REGION_SIZE_MIN 0x20
 
-/* application code would have enabled IRQ initially */
+/* default value setting for disabling interrupts */
 static unsigned int int_old_val = XIL_EXCEPTION_ALL;
 
 void sys_irq_restore_enable(void)
@@ -55,13 +55,10 @@ void sys_irq_restore_enable(void)
 
 void sys_irq_save_disable(void)
 {
-	unsigned int value = 0;
+	int_old_val = mfcpsr() & XIL_EXCEPTION_ALL;
 
-	value = mfcpsr() & XIL_EXCEPTION_ALL;
-
-	if (value != int_old_val) {
+	if (XIL_EXCEPTION_ALL != int_old_val) {
 		Xil_ExceptionDisableMask(XIL_EXCEPTION_ALL);
-		int_old_val = value;
 	}
 }
 


### PR DESCRIPTION
Fix issue that caused interrupts to not been disabled.
When cpsr.if was 0 and old value was 0, interrupt were not disabled.
This would happen if interrupt were initially enabled, after disabling, enabling and disabling again.
Changed sys_irq_save_disable() to read cpsr and compare interrupt bits to their disabled state, making sure interrupts gets disabled if different.