### PR TITLE
io: fix page_shift too big issue

### DIFF
--- a/lib/io.h
+++ b/lib/io.h
@@ -37,6 +37,7 @@
 #define __METAL_IO__H__
 
 #include <assert.h>
+#include <limits.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
@@ -177,7 +178,9 @@ metal_io_virt_to_offset(struct metal_io_region *io, void *virt)
 static inline metal_phys_addr_t
 metal_io_phys(struct metal_io_region *io, unsigned long offset)
 {
-	unsigned long page = offset >> io->page_shift;
+	unsigned long page = (io->page_shift >=
+			     sizeof(offset) * CHAR_BIT ?
+			     0 : offset >> io->page_shift);
 	return (io->physmap != NULL && offset <= io->size
 		&& io->physmap[page] != METAL_BAD_PHYS
 		? io->physmap[page] + (offset & io->page_mask)


### PR DESCRIPTION
When page_shift is larger than the number of bits of the offset
type, the offset shift operation will be undefined.
This fix detects if the page_shift is too big, if yes, the page
index will be "0".

Signed-off-by: Wendy Liang <jliang@xilinx.com>