### PR TITLE
cache: Add a veneer to allow for inline implementations

### DIFF
--- a/lib/cache.h
+++ b/lib/cache.h
@@ -36,9 +36,12 @@
 #ifndef __METAL_CACHE__H__
 #define __METAL_CACHE__H__
 
+#include <metal/system/@PROJECT_SYSTEM@/cache.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 
 /** \defgroup cache CACHE Interfaces
  *  @{ */
@@ -51,7 +54,10 @@ extern "C" {
  *                 If addr is NULL, and len is 0,
  *                 It will flush the whole data cache.
  */
-void metal_cache_flush(void *addr, unsigned int len);
+static inline void metal_cache_flush(void *addr, unsigned int len)
+{
+	return __metal_cache_flush(addr, len);
+}
 
 /**
  * @brief invalidate specified data cache
@@ -61,7 +67,10 @@ void metal_cache_flush(void *addr, unsigned int len);
  *                 If addr is NULL, and len is 0,
  *                 It will invalidate the whole data cache.
  */
-void metal_cache_invalidate(void *addr, unsigned int len);
+static inline void metal_cache_invalidate(void *addr, unsigned int len)
+{
+	return __metal_cache_invalidate(addr, len);
+}
 
 /** @} */
 

--- a/lib/system/freertos/CMakeLists.txt
+++ b/lib/system/freertos/CMakeLists.txt
@@ -1,11 +1,11 @@
 collect (PROJECT_LIB_HEADERS alloc.h)
+collect (PROJECT_LIB_HEADERS cache.h)
 collect (PROJECT_LIB_HEADERS condition.h)
 collect (PROJECT_LIB_HEADERS io.h)
 collect (PROJECT_LIB_HEADERS irq.h)
 collect (PROJECT_LIB_HEADERS mutex.h)
 collect (PROJECT_LIB_HEADERS sys.h)
 
-collect (PROJECT_LIB_SOURCES cache.c)
 collect (PROJECT_LIB_SOURCES condition.c)
 collect (PROJECT_LIB_SOURCES device.c)
 collect (PROJECT_LIB_SOURCES init.c)

--- a/lib/system/freertos/cache.h
+++ b/lib/system/freertos/cache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (c) 2018, Linaro Limited. and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
@@ -29,28 +29,36 @@
  */
 
 /*
- * @file	linux/cache.c
- * @brief	Linux libmetal cache handling.
+ * @file	freertos/cache.h
+ * @brief	FreeRTOS cache operation primitives for libmetal.
  */
 
-#include <metal/cache.h>
+#ifndef __METAL_CACHE__H__
+#error "Include metal/cache.h instead of metal/freertos/cache.h"
+#endif
 
-void metal_cache_flush(void *addr, unsigned int len)
+#ifndef __METAL_FREERTOS_CACHE__H__
+#define __METAL_FREERTOS_CACHE__H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void metal_machine_cache_flush(void *addr, unsigned int len);
+extern void metal_machine_cache_invalidate(void *addr, unsigned int len);
+
+void __metal_cache_flush(void *addr, unsigned int len)
 {
-	/** Do nothing.
-	 *  Do not flush cache from Linux userspace.
-	 */
-	(void)addr;
-	(void)len;
-	return;
+	metal_machine_cache_flush(addr, len);
 }
 
-void metal_cache_invalidate(void *addr, unsigned int len)
+void __metal_cache_invalidate(void *addr, unsigned int len)
 {
-	/** Do nothing.
-	 * Do not invalidate cache from Linux userspace.
-	 */
-	(void)addr;
-	(void)len;
-	return;
+	metal_machine_cache_invalidate(addr, len);
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_FREERTOS_CACHE__H__ */

--- a/lib/system/generic/CMakeLists.txt
+++ b/lib/system/generic/CMakeLists.txt
@@ -1,11 +1,11 @@
 collect (PROJECT_LIB_HEADERS alloc.h)
+collect (PROJECT_LIB_HEADERS cache.h)
 collect (PROJECT_LIB_HEADERS condition.h)
 collect (PROJECT_LIB_HEADERS io.h)
 collect (PROJECT_LIB_HEADERS irq.h)
 collect (PROJECT_LIB_HEADERS mutex.h)
 collect (PROJECT_LIB_HEADERS sys.h)
 
-collect (PROJECT_LIB_SOURCES cache.c)
 collect (PROJECT_LIB_SOURCES condition.c)
 collect (PROJECT_LIB_SOURCES device.c)
 collect (PROJECT_LIB_SOURCES init.c)

--- a/lib/system/generic/cache.h
+++ b/lib/system/generic/cache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (c) 2018, Linaro Limited. and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
@@ -29,21 +29,36 @@
  */
 
 /*
- * @file	freertos/cache.c
- * @brief	freertos libmetal cache handling.
+ * @file	generic/cache.h
+ * @brief	generic cache operation primitives for libmetal.
  */
 
-#include <metal/cache.h>
+#ifndef __METAL_CACHE__H__
+#error "Include metal/cache.h instead of metal/generic/cache.h"
+#endif
+
+#ifndef __METAL_GENERIC_CACHE__H__
+#define __METAL_GENERIC_CACHE__H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 extern void metal_machine_cache_flush(void *addr, unsigned int len);
 extern void metal_machine_cache_invalidate(void *addr, unsigned int len);
 
-void metal_cache_flush(void *addr, unsigned int len)
+void __metal_cache_flush(void *addr, unsigned int len)
 {
 	metal_machine_cache_flush(addr, len);
 }
 
-void metal_cache_invalidate(void *addr, unsigned int len)
+void __metal_cache_invalidate(void *addr, unsigned int len)
 {
 	metal_machine_cache_invalidate(addr, len);
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_GENERIC_CACHE__H__ */

--- a/lib/system/linux/CMakeLists.txt
+++ b/lib/system/linux/CMakeLists.txt
@@ -1,11 +1,11 @@
 collect (PROJECT_LIB_HEADERS alloc.h)
+collect (PROJECT_LIB_HEADERS cache.h)
 collect (PROJECT_LIB_HEADERS condition.h)
 collect (PROJECT_LIB_HEADERS io.h)
 collect (PROJECT_LIB_HEADERS irq.h)
 collect (PROJECT_LIB_HEADERS mutex.h)
 collect (PROJECT_LIB_HEADERS sys.h)
 
-collect (PROJECT_LIB_SOURCES cache.c)
 collect (PROJECT_LIB_SOURCES condition.c)
 collect (PROJECT_LIB_SOURCES device.c)
 collect (PROJECT_LIB_SOURCES init.c)

--- a/lib/system/linux/cache.h
+++ b/lib/system/linux/cache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (c) 2018, Linaro Limited. and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
@@ -29,21 +29,45 @@
  */
 
 /*
- * @file	generic/cache.c
- * @brief	generic libmetal cache handling.
+ * @file	linux/cache.h
+ * @brief	Linux cache operation primitives for libmetal.
  */
 
-#include <metal/cache.h>
+#ifndef __METAL_CACHE__H__
+#error "Include metal/cache.h instead of metal/linux/cache.h"
+#endif
 
-extern void metal_machine_cache_flush(void *addr, unsigned int len);
-extern void metal_machine_cache_invalidate(void *addr, unsigned int len);
+#ifndef __METAL_LINUX_CACHE__H__
+#define __METAL_LINUX_CACHE__H__
 
-void metal_cache_flush(void *addr, unsigned int len)
+#include <metal/utilities.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline void __metal_cache_flush(void *addr, unsigned int len)
 {
-	metal_machine_cache_flush(addr, len);
+	/** Do nothing.
+	 *  Do not flush cache from Linux userspace.
+	 */
+	metal_unused(addr);
+	metal_unused(len);
+	return;
 }
 
-void metal_cache_invalidate(void *addr, unsigned int len)
+static inline void __metal_cache_invalidate(void *addr, unsigned int len)
 {
-	metal_machine_cache_invalidate(addr, len);
+	/** Do nothing.
+	 *  Do not flush cache from Linux userspace.
+	 */
+	metal_unused(addr);
+	metal_unused(len);
+	return;
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_LINUX_CACHE__H__ */

--- a/lib/system/zephyr/CMakeLists.txt
+++ b/lib/system/zephyr/CMakeLists.txt
@@ -1,4 +1,5 @@
 collect (PROJECT_LIB_HEADERS alloc.h)
+collect (PROJECT_LIB_HEADERS cache.h)
 collect (PROJECT_LIB_HEADERS condition.h)
 collect (PROJECT_LIB_HEADERS io.h)
 collect (PROJECT_LIB_HEADERS irq.h)
@@ -6,7 +7,6 @@ collect (PROJECT_LIB_HEADERS mutex.h)
 collect (PROJECT_LIB_HEADERS sys.h)
 
 collect (PROJECT_LIB_SOURCES alloc.c)
-collect (PROJECT_LIB_SOURCES cache.c)
 collect (PROJECT_LIB_SOURCES condition.c)
 collect (PROJECT_LIB_SOURCES device.c)
 collect (PROJECT_LIB_SOURCES init.c)

--- a/lib/system/zephyr/cache.h
+++ b/lib/system/zephyr/cache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Linaro Limited. and Contributors. All rights reserved.
+ * Copyright (c) 2018, Linaro Limited. and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -29,21 +29,39 @@
  */
 
 /*
- * @file	zephyr/cache.c
- * @brief	Zephyr libmetal cache handling.
+ * @file	zephyr/cache.h
+ * @brief	Zephyr cache operation primitives for libmetal.
  */
 
-#include <metal/cache.h>
+#ifndef __METAL_CACHE__H__
+#error "Include metal/cache.h instead of metal/zephyr/cache.h"
+#endif
 
-extern void metal_machine_cache_flush(void *addr, unsigned int len);
-extern void metal_machine_cache_invalidate(void *addr, unsigned int len);
+#ifndef __METAL_ZEPHYR_CACHE__H__
+#define __METAL_ZEPHYR_CACHE__H__
 
-void metal_cache_flush(void *addr, unsigned int len)
+#include <metal/utilities.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline void __metal_cache_flush(void *addr, unsigned int len)
 {
-	metal_machine_cache_flush(addr, len);
+	metal_unused(addr);
+	metal_unused(len);
+	return;
 }
 
-void metal_cache_invalidate(void *addr, unsigned int len)
+static inline void __metal_cache_invalidate(void *addr, unsigned int len)
 {
-	metal_machine_cache_invalidate(addr, len);
+	metal_unused(addr);
+	metal_unused(len);
+	return;
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_ZEPHYR_CACHE__H__ */

--- a/lib/system/zephyr/cortexm/sys.c
+++ b/lib/system/zephyr/cortexm/sys.c
@@ -37,20 +37,6 @@
 #include <metal/sys.h>
 #include <stdint.h>
 
-void metal_machine_cache_flush(void *addr, unsigned int len)
-{
-	/* Fix me */
-	(void)addr;
-	(void)len;
-}
-
-void metal_machine_cache_invalidate(void *addr, unsigned int len)
-{
-	/* Fix me */
-	(void)addr;
-	(void)len;
-}
-
 /**
  * @brief poll function until some event happens
  */


### PR DESCRIPTION
To allow for smaller code or the ability to optimize away code that we
dont use add an veneer for the cache functions.  This way the system specific
code can decide how to implement the functions and do them completely inline
if desired.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>