### PR TITLE
compiler: Fix restrict definition

### DIFF
--- a/lib/compiler/gcc/compiler.h
+++ b/lib/compiler/gcc/compiler.h
@@ -38,9 +38,9 @@
 
 #ifdef __cplusplus
 extern "C" {
-#define restrict __restrict__
 #endif
 
+#define restrict __restrict__
 #define metal_align(n) __attribute__((aligned(n)))
 
 #ifdef __cplusplus


### PR DESCRIPTION
The define of restrict was inside the c++ extern define block.  This
causes issues on older toolchains.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>