### PR TITLE
ci: fix Zephyr CI compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - if [[ "$TARGET" == "zephyr" ]]; then
       sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test &&
       sudo apt-get update -qq &&
-      sudo apt-get install libsysfs-dev libhugetlbfs-dev libc6-dev-i386 make gperf gcc g++ python3-ply python3-yaml python3-pip device-tree-compiler ncurses-dev uglifyjs -qq &&
+      sudo apt-get install libc6-dev-i386 make gperf gcc g++ python3-ply python3-yaml python3-pip device-tree-compiler ncurses-dev uglifyjs -qq &&
       sudo pip3 install pyelftools;
     fi
   - if [[ "$TARGET" == "linux" ]]; then
@@ -61,7 +61,7 @@ script:
   - if [[ "$TARGET" == "zephyr" ]]; then
        mkdir -p ../libmetal/build-zephyr &&
        cd ../libmetal/build-zephyr &&
-       cmake .. &&
+       cmake .. -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_m3 &&
        make VERBOSE=1;
     fi
   - if [[ "$TARGET" == "linux" ]]; then


### PR DESCRIPTION
Compile Zephyr instead of Linux in the Zephyr CI build.

Signed-off-by: Wendy Liang <jliang@xilinx.com>