### PR TITLE
metal_phys_addr_t size depends on machine addr size

### DIFF
--- a/lib/sys.h
+++ b/lib/sys.h
@@ -50,7 +50,15 @@ extern "C" {
  *  @{ */
 
 /** Physical address type. */
+#ifdef ADDR_64BIT
+#warning "64bit address"
+typedef uint64_t metal_phys_addr_t;
+#elif ADDR_32BIT
+#warning "32bit address"
+typedef uint32_t metal_phys_addr_t;
+#else
 typedef unsigned long metal_phys_addr_t;
+#endif
 
 /** Interrupt request number. */
 typedef int metal_irq_t;


### PR DESCRIPTION
There can be 32bit machine with capability to access
64bit address. The metal_phys_addr_t size in this case
should be 64bit.

Signed-off-by: Wendy Liang <jliang@xilinx.com>