### PR TITLE
Fix license text for files in lib/system/zephyr

### DIFF
--- a/lib/system/zephyr/alloc.c
+++ b/lib/system/zephyr/alloc.c
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/alloc.h
+++ b/lib/system/zephyr/alloc.h
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/cache.c
+++ b/lib/system/zephyr/cache.c
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/condition.c
+++ b/lib/system/zephyr/condition.c
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/condition.h
+++ b/lib/system/zephyr/condition.h
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/cortexm/sys.c
+++ b/lib/system/zephyr/cortexm/sys.c
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/cortexm/sys.h
+++ b/lib/system/zephyr/cortexm/sys.h
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/device.c
+++ b/lib/system/zephyr/device.c
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/init.c
+++ b/lib/system/zephyr/init.c
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/io.c
+++ b/lib/system/zephyr/io.c
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/io.h
+++ b/lib/system/zephyr/io.h
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/irq.c
+++ b/lib/system/zephyr/irq.c
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/irq.h
+++ b/lib/system/zephyr/irq.h
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/mutex.h
+++ b/lib/system/zephyr/mutex.h
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/shmem.c
+++ b/lib/system/zephyr/shmem.c
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/sleep.c
+++ b/lib/system/zephyr/sleep.c
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/sys.h
+++ b/lib/system/zephyr/sys.h
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/lib/system/zephyr/time.c
+++ b/lib/system/zephyr/time.c
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *

--- a/test/system/zephyr/metal-test-internal.h
+++ b/test/system/zephyr/metal-test-internal.h
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Xilinx nor the names of its contributors may be used
+ * 3. Neither the name of Linaro nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *


### PR DESCRIPTION
Put Linaro to the license text in the files of libmetal
Zephyr implementation.

Signed-off-by: Wendy Liang <jliang@xilinx.com>