### PR TITLE
compiler: introduce metal_weak macro

### DIFF
--- a/lib/compiler/gcc/compiler.h
+++ b/lib/compiler/gcc/compiler.h
@@ -42,6 +42,7 @@ extern "C" {
 
 #define restrict __restrict__
 #define metal_align(n) __attribute__((aligned(n)))
+#define metal_weak __attribute__((weak))
 
 #ifdef __cplusplus
 }

--- a/lib/system/freertos/zynq7/sys.c
+++ b/lib/system/freertos/zynq7/sys.c
@@ -87,7 +87,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
 /**
  * @brief poll function until some event happens
  */
-void __attribute__((weak)) metal_generic_default_poll(void)
+void metal_weak metal_generic_default_poll(void)
 {
 	asm volatile("wfi");
 }

--- a/lib/system/freertos/zynqmp_a53/sys.c
+++ b/lib/system/freertos/zynqmp_a53/sys.c
@@ -81,7 +81,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
 /**
  * @brief poll function until some event happens
  */
-void __attribute__((weak)) metal_generic_default_poll(void)
+void metal_weak metal_generic_default_poll(void)
 {
 	asm volatile("wfi");
 }

--- a/lib/system/freertos/zynqmp_r5/sys.c
+++ b/lib/system/freertos/zynqmp_r5/sys.c
@@ -81,7 +81,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
 /**
  * @brief poll function until some event happens
  */
-void __attribute__((weak)) metal_generic_default_poll(void)
+void metal_weak metal_generic_default_poll(void)
 {
 	asm volatile("wfi");
 }

--- a/lib/system/generic/microblaze_generic/sys.c
+++ b/lib/system/generic/microblaze_generic/sys.c
@@ -111,12 +111,12 @@ static void sys_irq_change(unsigned int vector, int is_enable)
 #endif
 }
 
-void __attribute__((weak)) sys_irq_enable(unsigned int vector)
+void metal_weak sys_irq_enable(unsigned int vector)
 {
 	sys_irq_change(vector, 1);
 }
 
-void __attribute__((weak)) sys_irq_disable(unsigned int vector)
+void metal_weak sys_irq_disable(unsigned int vector)
 {
 	sys_irq_change(vector, 0);
 }
@@ -145,7 +145,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
 /**
  * @brief make microblaze wait
  */
-void __attribute__((weak)) metal_generic_default_poll(void)
+void metal_weak metal_generic_default_poll(void)
 {
 	asm volatile("nop");
 }

--- a/lib/system/generic/microblaze_generic/sys.h
+++ b/lib/system/generic/microblaze_generic/sys.h
@@ -46,9 +46,9 @@ extern "C" {
 
 #ifdef METAL_INTERNAL
 
-void __attribute__((weak)) sys_irq_enable(unsigned int vector);
+void metal_weak sys_irq_enable(unsigned int vector);
 
-void __attribute__((weak)) sys_irq_disable(unsigned int vector);
+void metal_weak sys_irq_disable(unsigned int vector);
 
 #endif /* METAL_INTERNAL */
 

--- a/lib/system/generic/zynq7/sys.c
+++ b/lib/system/generic/zynq7/sys.c
@@ -84,7 +84,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
 /**
  * @brief poll function until some event happens
  */
-void __attribute__((weak)) metal_generic_default_poll(void)
+void metal_weak metal_generic_default_poll(void)
 {
 	asm volatile("wfi");
 }

--- a/lib/system/generic/zynqmp_a53/sys.c
+++ b/lib/system/generic/zynqmp_a53/sys.c
@@ -81,7 +81,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
 /**
  * @brief poll function until some event happens
  */
-void __attribute__((weak)) metal_generic_default_poll(void)
+void metal_weak metal_generic_default_poll(void)
 {
 	asm volatile("wfi");
 }

--- a/lib/system/generic/zynqmp_r5/sys.c
+++ b/lib/system/generic/zynqmp_r5/sys.c
@@ -81,7 +81,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
 /**
  * @brief poll function until some event happens
  */
-void __attribute__((weak)) metal_generic_default_poll(void)
+void metal_weak metal_generic_default_poll(void)
 {
 	asm volatile("wfi");
 }

--- a/lib/system/zephyr/alloc.c
+++ b/lib/system/zephyr/alloc.c
@@ -34,16 +34,17 @@
  */
 
 #include <metal/alloc.h>
+#include <metal/compiler.h>
 
 #if (CONFIG_HEAP_MEM_POOL_SIZE <= 0)
 
-void* __attribute__((weak)) metal_zephyr_allocate_memory(unsigned int size)
+void* metal_weak metal_zephyr_allocate_memory(unsigned int size)
 {
 	(void)size;
 	return NULL;
 }
 
-void __attribute__((weak)) metal_zephyr_free_memory(void *ptr)
+void metal_weak metal_zephyr_free_memory(void *ptr)
 {
 	(void)ptr;
 }

--- a/lib/system/zephyr/cortexm/sys.c
+++ b/lib/system/zephyr/cortexm/sys.c
@@ -54,7 +54,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
 /**
  * @brief poll function until some event happens
  */
-void __attribute__((weak)) metal_generic_default_poll(void)
+void metal_weak metal_generic_default_poll(void)
 {
 	__asm__ __volatile__("wfi");
 }

--- a/test/metal-test.c
+++ b/test/metal-test.c
@@ -42,7 +42,7 @@ static METAL_DECLARE_LIST(test_cases);
  * Not every enviornment has strerror() implemented.
  */
 #ifdef NOT_HAVE_STRERROR
-char __attribute__((weak)) *strerror(int errnum)
+char metal_weak *strerror(int errnum)
 {
 	static char errstr[33];
 	int i, j;


### PR DESCRIPTION
Introduce a macro to abstract how we define a weak function as this
tends to be compiler specific.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>