### PR TITLE
ci: zephyr: enable to build with tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ script:
   - if [[ "$TARGET" == "zephyr" ]]; then
        mkdir -p ../libmetal/build-zephyr &&
        cd ../libmetal/build-zephyr &&
-       cmake .. -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_m3 &&
+       cmake .. -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_m3 -DWITH_TESTS=on &&
        make VERBOSE=1;
     fi
   - if [[ "$TARGET" == "linux" ]]; then


### PR DESCRIPTION
Build with tests enabled for Zephyr in CI.

Signed-off-by: Wendy Liang <jliang@xilinx.com>