### PR TITLE
cmake: options: remove check for xintc

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -53,11 +53,4 @@ option (WITH_DEFAULT_LOGGER "Build with default logger" ON)
 option (WITH_DOC "Build with documentation" ON)
 
 set (PROJECT_EC_FLAGS "-Wall -Werror -Wextra" CACHE STRING "")
-
-check_include_files(xintc.h HAS_XINTC)
-if (HAS_XINTC STREQUAL "1")
-  get_property(PROJECT_EC_FLAGS DIRECTORY PROPERTY PROJECT_EC_FLAGS)
-  set(PROJECT_EC_FLAGS "${PROJECT_EC_FLAGS} -DHAS_XINTC" )
-endif(HAS_XINTC STREQUAL "1")
-
 # vim: expandtab:ts=2:sw=2:smartindent


### PR DESCRIPTION
Previously the check for xilinx interrupt controller driver was done for
microblaze generic platform in top level cmake directory. As this is now handled
by microblaze generic platform in lib/ remove this check.

Signed-off-by: Ben Levinsky <ben.levinsky@xilinx.com>