### PR TITLE
Metal assertions

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -5,6 +5,7 @@ collect (PROJECT_LIB_DIRS "${CMAKE_CURRENT_BINARY_DIR}")
 collect (PROJECT_INC_DIRS "${CMAKE_CURRENT_BINARY_DIR}/include")
 
 collect (PROJECT_LIB_HEADERS alloc.h)
+collect (PROJECT_LIB_HEADERS assert.h)
 collect (PROJECT_LIB_HEADERS atomic.h)
 collect (PROJECT_LIB_HEADERS cache.h)
 collect (PROJECT_LIB_HEADERS compiler.h)

--- a/lib/assert.h
+++ b/lib/assert.h
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Linaro nor the names of its contributors may be used
+ * 3. Neither the name of Xilinx nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
@@ -29,36 +29,20 @@
  */
 
 /*
- * @file	zephyr/log.c
- * @brief	Zephyr libmetal log handler.
+ * @file	assert.h
+ * @brief	Assertion support.
  */
 
-#include <stdarg.h>
-#include <metal/log.h>
-#include <zephyr.h>
+#ifndef __METAL_ASSERT__H__
+#define __METAL_ASSERT__H__
 
-static const char *level_strs[] = {
-	"metal: emergency: ",
-	"metal: alert:     ",
-	"metal: critical:  ",
-	"metal: error:     ",
-	"metal: warning:   ",
-	"metal: notice:    ",
-	"metal: info:      ",
-	"metal: debug:     ",
-};
+#include <metal/system/@PROJECT_SYSTEM@/assert.h>
 
-void metal_zephyr_log_handler(enum metal_log_level level,
-			      const char *format, ...)
-{
-	va_list args;
+/**
+ * @brief Assertion macro.
+ * @param cond Condition to test.
+ */
+#define metal_assert(cond) metal_sys_assert(cond)
 
-	if (level <= METAL_LOG_EMERGENCY || level > METAL_LOG_DEBUG)
-		level = METAL_LOG_EMERGENCY;
-	printk("%s", level_strs[level]);
-
-	va_start(args, format);
-	vprintk(format, args);
-	va_end(args);
-}
+#endif /* __METAL_ASSERT_H__ */
 

--- a/lib/device.c
+++ b/lib/device.c
@@ -30,6 +30,7 @@
 
 #include <string.h>
 #include <errno.h>
+#include <metal/assert.h>
 #include <metal/device.h>
 #include <metal/list.h>
 #include <metal/log.h>
@@ -113,7 +114,7 @@ int metal_device_open(const char *bus_name, const char *dev_name,
 
 void metal_device_close(struct metal_device *device)
 {
-	assert(device && device->bus);
+	metal_assert(device && device->bus);
 	if (device->bus != &metal_generic_bus)
 		metal_list_del(&device->node);
 	if (device->bus->ops.dev_close)

--- a/lib/io.h
+++ b/lib/io.h
@@ -36,11 +36,11 @@
 #ifndef __METAL_IO__H__
 #define __METAL_IO__H__
 
-#include <assert.h>
 #include <limits.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
+#include <metal/assert.h>
 #include <metal/compiler.h>
 #include <metal/atomic.h>
 #include <metal/sys.h>
@@ -264,7 +264,7 @@ metal_io_read(struct metal_io_region *io, unsigned long offset,
 #else
 		return metal_processor_io_read64((atomic_ullong *)ptr, order);
 #endif
-	assert(0);
+	metal_assert(0);
 	return 0; /* quiet compiler */
 }
 
@@ -300,7 +300,7 @@ metal_io_write(struct metal_io_region *io, unsigned long offset,
 		metal_processor_io_write64((atomic_ullong *)ptr, value, order);
 #endif
 	else
-		assert (0);
+		metal_assert (0);
 }
 
 #define metal_io_read8_explicit(_io, _ofs, _order)			\

--- a/lib/shmem.c
+++ b/lib/shmem.c
@@ -34,6 +34,7 @@
  */
 
 #include <errno.h>
+#include <metal/assert.h>
 #include <metal/shmem.h>
 #include <metal/sys.h>
 #include <metal/utilities.h>
@@ -41,10 +42,10 @@
 int metal_shmem_register_generic(struct metal_generic_shmem *shmem)
 {
 	/* Make sure that we can be found. */
-	assert(shmem->name && strlen(shmem->name) != 0);
+	metal_assert(shmem->name && strlen(shmem->name) != 0);
 
 	/* Statically registered shmem regions cannot have a destructor. */
-	assert(!shmem->io.ops.close);
+	metal_assert(!shmem->io.ops.close);
 
 	metal_list_add_tail(&_metal.common.generic_shmem_list,
 			    &shmem->node);

--- a/lib/system/freertos/CMakeLists.txt
+++ b/lib/system/freertos/CMakeLists.txt
@@ -1,4 +1,5 @@
 collect (PROJECT_LIB_HEADERS alloc.h)
+collect (PROJECT_LIB_HEADERS assert.h)
 collect (PROJECT_LIB_HEADERS cache.h)
 collect (PROJECT_LIB_HEADERS condition.h)
 collect (PROJECT_LIB_HEADERS io.h)

--- a/lib/system/freertos/assert.h
+++ b/lib/system/freertos/assert.h
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Linaro nor the names of its contributors may be used
+ * 3. Neither the name of Xilinx nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
@@ -29,36 +29,23 @@
  */
 
 /*
- * @file	zephyr/log.c
- * @brief	Zephyr libmetal log handler.
+ * @file	assert.h
+ * @brief	FreeRTOS assertion support.
  */
+#ifndef __METAL_ASSERT__H__
+#error "Include metal/assert.h instead of metal/freertos/assert.h"
+#endif
 
-#include <stdarg.h>
-#include <metal/log.h>
-#include <zephyr.h>
+#ifndef __METAL_FREERTOS_ASSERT__H__
+#define __METAL_FREERTOS_ASSERT__H__
 
-static const char *level_strs[] = {
-	"metal: emergency: ",
-	"metal: alert:     ",
-	"metal: critical:  ",
-	"metal: error:     ",
-	"metal: warning:   ",
-	"metal: notice:    ",
-	"metal: info:      ",
-	"metal: debug:     ",
-};
+#include <assert.h>
 
-void metal_zephyr_log_handler(enum metal_log_level level,
-			      const char *format, ...)
-{
-	va_list args;
+/**
+ * @brief Assertion macro for FreeRTOS applications.
+ * @param cond Condition to evaluate.
+ */
+#define metal_sys_assert(cond) assert(cond)
 
-	if (level <= METAL_LOG_EMERGENCY || level > METAL_LOG_DEBUG)
-		level = METAL_LOG_EMERGENCY;
-	printk("%s", level_strs[level]);
-
-	va_start(args, format);
-	vprintk(format, args);
-	va_end(args);
-}
+#endif /* __METAL_FREERTOS_ASSERT__H__ */
 

--- a/lib/system/freertos/mutex.h
+++ b/lib/system/freertos/mutex.h
@@ -40,7 +40,7 @@
 #ifndef __METAL_FREERTOS_MUTEX__H__
 #define __METAL_FREERTOS_MUTEX__H__
 
-#include <assert.h>
+#include <metal/assert.h>
 #include "FreeRTOS.h"
 #include "semphr.h"
 
@@ -57,39 +57,39 @@ typedef struct {
 
 static inline void __metal_mutex_init(metal_mutex_t *mutex)
 {
-	assert(mutex);
+	metal_assert(mutex);
 	mutex->m = xSemaphoreCreateMutex();
-	assert(mutex->m != NULL);
+	metal_assert(mutex->m != NULL);
 }
 
 static inline void __metal_mutex_deinit(metal_mutex_t *mutex)
 {
-	assert(mutex && mutex->m != NULL);
+	metal_assert(mutex && mutex->m != NULL);
 	vSemaphoreDelete(mutex->m);
 	mutex->m=NULL;
 }
 
 static inline int __metal_mutex_try_acquire(metal_mutex_t *mutex)
 {
-	assert(mutex && mutex->m != NULL);
+	metal_assert(mutex && mutex->m != NULL);
 	return xSemaphoreTake(mutex->m, ( TickType_t ) 0 );
 }
 
 static inline void __metal_mutex_acquire(metal_mutex_t *mutex)
 {
-	assert(mutex && mutex->m != NULL);
+	metal_assert(mutex && mutex->m != NULL);
 	xSemaphoreTake(mutex->m, portMAX_DELAY);
 }
 
 static inline void __metal_mutex_release(metal_mutex_t *mutex)
 {
-	assert(mutex && mutex->m != NULL);
+	metal_assert(mutex && mutex->m != NULL);
 	xSemaphoreGive(mutex->m);
 }
 
 static inline int __metal_mutex_is_acquired(metal_mutex_t *mutex)
 {
-	assert(mutex && mutex->m != NULL);
+	metal_assert(mutex && mutex->m != NULL);
 	return (NULL == xSemaphoreGetMutexHolder(mutex->m)) ? 0 : 1;
 }
 

--- a/lib/system/generic/CMakeLists.txt
+++ b/lib/system/generic/CMakeLists.txt
@@ -1,4 +1,5 @@
 collect (PROJECT_LIB_HEADERS alloc.h)
+collect (PROJECT_LIB_HEADERS assert.h)
 collect (PROJECT_LIB_HEADERS cache.h)
 collect (PROJECT_LIB_HEADERS condition.h)
 collect (PROJECT_LIB_HEADERS io.h)

--- a/lib/system/generic/assert.h
+++ b/lib/system/generic/assert.h
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Linaro nor the names of its contributors may be used
+ * 3. Neither the name of Xilinx nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
@@ -29,36 +29,24 @@
  */
 
 /*
- * @file	zephyr/log.c
- * @brief	Zephyr libmetal log handler.
+ * @file	assert.h
+ * @brief	Generic assertion support.
  */
 
-#include <stdarg.h>
-#include <metal/log.h>
-#include <zephyr.h>
+#ifndef __METAL_ASSERT__H__
+#error "Include metal/assert.h instead of metal/generic/assert.h"
+#endif
 
-static const char *level_strs[] = {
-	"metal: emergency: ",
-	"metal: alert:     ",
-	"metal: critical:  ",
-	"metal: error:     ",
-	"metal: warning:   ",
-	"metal: notice:    ",
-	"metal: info:      ",
-	"metal: debug:     ",
-};
+#ifndef __METAL_GENERIC_ASSERT__H__
+#define __METAL_GENERIC_ASSERT__H__
 
-void metal_zephyr_log_handler(enum metal_log_level level,
-			      const char *format, ...)
-{
-	va_list args;
+#include <assert.h>
 
-	if (level <= METAL_LOG_EMERGENCY || level > METAL_LOG_DEBUG)
-		level = METAL_LOG_EMERGENCY;
-	printk("%s", level_strs[level]);
+/**
+ * @brief Assertion macro for bare-metal applications.
+ * @param cond Condition to evaluate.
+ */
+#define metal_sys_assert(cond) assert(cond)
 
-	va_start(args, format);
-	vprintk(format, args);
-	va_end(args);
-}
+#endif /* __METAL_GENERIC_ASSERT__H__ */
 

--- a/lib/system/generic/microblaze_generic/sys.c
+++ b/lib/system/generic/microblaze_generic/sys.c
@@ -33,6 +33,7 @@
  * @brief	machine specific system primitives implementation.
  */
 
+#include <metal/assert.h>
 #include <metal/io.h>
 #include <metal/sys.h>
 #include <stdint.h>
@@ -107,7 +108,7 @@ static void sys_irq_change(unsigned int vector, int is_enable)
 #else
 	(void)vector;
 	(void)is_enable;
-	assert(0);
+	metal_assert(0);
 #endif
 }
 

--- a/lib/system/linux/CMakeLists.txt
+++ b/lib/system/linux/CMakeLists.txt
@@ -1,4 +1,5 @@
 collect (PROJECT_LIB_HEADERS alloc.h)
+collect (PROJECT_LIB_HEADERS assert.h)
 collect (PROJECT_LIB_HEADERS cache.h)
 collect (PROJECT_LIB_HEADERS condition.h)
 collect (PROJECT_LIB_HEADERS io.h)

--- a/lib/system/linux/assert.h
+++ b/lib/system/linux/assert.h
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Linaro nor the names of its contributors may be used
+ * 3. Neither the name of Xilinx nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
@@ -29,36 +29,24 @@
  */
 
 /*
- * @file	zephyr/log.c
- * @brief	Zephyr libmetal log handler.
+ * @file	assert.h
+ * @brief	Linux assertion support.
  */
 
-#include <stdarg.h>
-#include <metal/log.h>
-#include <zephyr.h>
+#ifndef __METAL_ASSERT__H__
+#error "Include metal/assert.h instead of metal/linux/assert.h"
+#endif
 
-static const char *level_strs[] = {
-	"metal: emergency: ",
-	"metal: alert:     ",
-	"metal: critical:  ",
-	"metal: error:     ",
-	"metal: warning:   ",
-	"metal: notice:    ",
-	"metal: info:      ",
-	"metal: debug:     ",
-};
+#ifndef __METAL_LINUX_ASSERT__H__
+#define __METAL_LINUX_ASSERT__H__
 
-void metal_zephyr_log_handler(enum metal_log_level level,
-			      const char *format, ...)
-{
-	va_list args;
+#include <assert.h>
 
-	if (level <= METAL_LOG_EMERGENCY || level > METAL_LOG_DEBUG)
-		level = METAL_LOG_EMERGENCY;
-	printk("%s", level_strs[level]);
+/**
+ * @brief Assertion macro for Linux-based applications.
+ * @param cond Condition to evaluate.
+ */
+#define metal_sys_assert(cond) assert(cond)
 
-	va_start(args, format);
-	vprintk(format, args);
-	va_end(args);
-}
+#endif /* __METAL_LINUX_ASSERT__H__ */
 

--- a/lib/system/zephyr/CMakeLists.txt
+++ b/lib/system/zephyr/CMakeLists.txt
@@ -1,4 +1,5 @@
 collect (PROJECT_LIB_HEADERS alloc.h)
+collect (PROJECT_LIB_HEADERS assert.h)
 collect (PROJECT_LIB_HEADERS cache.h)
 collect (PROJECT_LIB_HEADERS condition.h)
 collect (PROJECT_LIB_HEADERS io.h)

--- a/lib/system/zephyr/assert.h
+++ b/lib/system/zephyr/assert.h
@@ -11,7 +11,7 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * 3. Neither the name of Linaro nor the names of its contributors may be used
+ * 3. Neither the name of Xilinx nor the names of its contributors may be used
  *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
@@ -29,36 +29,24 @@
  */
 
 /*
- * @file	zephyr/log.c
- * @brief	Zephyr libmetal log handler.
+ * @file	assert.h
+ * @brief	Zephyr assertion support.
  */
 
-#include <stdarg.h>
-#include <metal/log.h>
+#ifndef __METAL_ASSERT__H__
+#error "Include metal/assert.h instead of metal/zephyr/assert.h"
+#endif
+
+#ifndef __METAL_ZEPHYR_ASSERT__H__
+#define __METAL_ZEPHYR_ASSERT__H__
+
 #include <zephyr.h>
 
-static const char *level_strs[] = {
-	"metal: emergency: ",
-	"metal: alert:     ",
-	"metal: critical:  ",
-	"metal: error:     ",
-	"metal: warning:   ",
-	"metal: notice:    ",
-	"metal: info:      ",
-	"metal: debug:     ",
-};
+/**
+ * @brief Assertion macro for Zephyr-based applications.
+ * @param cond Condition to evaluate.
+ */
+#define metal_sys_assert(cond) __ASSERT_NO_MSG(cond)
 
-void metal_zephyr_log_handler(enum metal_log_level level,
-			      const char *format, ...)
-{
-	va_list args;
-
-	if (level <= METAL_LOG_EMERGENCY || level > METAL_LOG_DEBUG)
-		level = METAL_LOG_EMERGENCY;
-	printk("%s", level_strs[level]);
-
-	va_start(args, format);
-	vprintk(format, args);
-	va_end(args);
-}
+#endif /* __METAL_ZEPHYR_ASSERT__H__ */
 

--- a/lib/system/zephyr/log.h
+++ b/lib/system/zephyr/log.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2018, Nordic Semiconductor ASA and Contributors.
- * All rights reserved.
+ * Copyright (c) 2018, Xilinx Inc. and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/utilities.h
+++ b/lib/utilities.h
@@ -36,8 +36,8 @@
 #ifndef __METAL_UTILITIES__H__
 #define __METAL_UTILITIES__H__
 
-#include <assert.h>
 #include <stdint.h>
+#include <metal/assert.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -160,7 +160,7 @@ static inline unsigned long metal_log2(unsigned long in)
 {
 	unsigned long result;
 
-	assert((in & (in - 1)) == 0);
+	metal_assert((in & (in - 1)) == 0);
 
 	for (result = 0; (1UL << result) < in; result ++)
 		;


### PR DESCRIPTION
This PR proposes to add a `metal_assert()` macro to libmetal. This allows applications to avoid the dependency on the implementation of `assert()` from the standard library, which can pull in functions from [stdio](https://sourceware.org/git/gitweb.cgi?p=newlib-cygwin.git;a=blob;f=newlib/libc/stdlib/assert.c) or other places depending on the library.

This PR links `metal_assert()` to the `__ASSERT()` macro when used for Zephyr or the standard libc `assert()` otherwise.

This will also be useful when cleaning up the assert usage in OpenAMP, where several different macros (with different implementations) are used.