### PR TITLE
io: add names property of metal I/O region

### DIFF
--- a/lib/io.h
+++ b/lib/io.h
@@ -90,6 +90,7 @@ struct metal_io_ops {
 
 /** Libmetal I/O region structure. */
 struct metal_io_region {
+	char name[32];                      /**< name of the I/O region */
 	void			*virt;      /**< base virtual address */
 	const metal_phys_addr_t	*physmap;   /**< table of base physical address
                                                  of each of the pages in the I/O


### PR DESCRIPTION
Each I/O region can have a name, so that the user can know
what the I/O region is for.

This will line up with carve out memory in the resource table. In the OpenAMP implementation, each remoteproc can have a libmetal device, and each device manage its register I/O regions and shared memory I/O regions.

Signed-off-by: Wendy Liang <jliang@xilinx.com>