### PR TITLE
rework irqs_ init to reduce code size

### DIFF
--- a/lib/list.h
+++ b/lib/list.h
@@ -25,8 +25,17 @@ struct metal_list {
 	struct metal_list *next, *prev;
 };
 
+/*
+ * METAL_INIT_LIST - used for initializing an list elmenet in a static struct
+ * or global
+ */
+#define METAL_INIT_LIST(name) { .next = &name, .prev = &name }
+/*
+ * METAL_DECLARE_LIST - used for defining and initializing a global or
+ * static singleton list
+ */
 #define METAL_DECLARE_LIST(name)			\
-	struct metal_list name = { .next = &name, .prev = &name }
+	struct metal_list name = METAL_INIT_LIST(name)
 
 static inline void metal_list_init(struct metal_list *list)
 {

--- a/lib/system/freertos/mutex.h
+++ b/lib/system/freertos/mutex.h
@@ -29,7 +29,16 @@ typedef struct {
 	SemaphoreHandle_t m;
 } metal_mutex_t;
 
-#define METAL_MUTEX_DEFINE(m) metal_mutex_t m = { NULL }
+/*
+ * METAL_MUTEX_INIT - used for initializing an mutex elmenet in a static struct
+ * or global
+ */
+#define METAL_MUTEX_INIT(m) { NULL }
+/*
+ * METAL_MUTEX_DEFINE - used for defining and initializing a global or
+ * static singleton mutex
+ */
+#define METAL_MUTEX_DEFINE(m) metal_mutex_t m = METAL_MUTEX_INIT(m)
 
 static inline void __metal_mutex_init(metal_mutex_t *mutex)
 {

--- a/lib/system/generic/mutex.h
+++ b/lib/system/generic/mutex.h
@@ -26,7 +26,16 @@ typedef struct {
 	atomic_int v;
 } metal_mutex_t;
 
-#define METAL_MUTEX_DEFINE(m) metal_mutex_t m = { ATOMIC_VAR_INIT(0) }
+/*
+ * METAL_MUTEX_INIT - used for initializing an mutex elmenet in a static struct
+ * or global
+ */
+#define METAL_MUTEX_INIT(m) { ATOMIC_VAR_INIT(0) }
+/*
+ * METAL_MUTEX_DEFINE - used for defining and initializing a global or
+ * static singleton mutex
+ */
+#define METAL_MUTEX_DEFINE(m) metal_mutex_t m = METAL_MUTEX_INIT(m)
 
 static inline void __metal_mutex_init(metal_mutex_t *mutex)
 {

--- a/lib/system/linux/mutex.h
+++ b/lib/system/linux/mutex.h
@@ -30,6 +30,15 @@ typedef struct {
 	atomic_int v;
 } metal_mutex_t;
 
+/*
+ * METAL_MUTEX_INIT - used for initializing an mutex elmenet in a static struct
+ * or global
+ */
+#define METAL_MUTEX_INIT(m) { ATOMIC_VAR_INIT(0) }
+/*
+ * METAL_MUTEX_DEFINE - used for defining and initializing a global or
+ * static singleton mutex
+ */
 #define METAL_MUTEX_DEFINE(m) metal_mutex_t m = { ATOMIC_VAR_INIT(0) }
 
 static inline int __metal_mutex_cmpxchg(metal_mutex_t *mutex,

--- a/lib/system/zephyr/init.c
+++ b/lib/system/zephyr/init.c
@@ -13,19 +13,15 @@
 #include <metal/sys.h>
 #include <metal/utilities.h>
 
-extern int metal_irq_init(void);
-extern void metal_irq_deinit(void);
-
 struct metal_state _metal;
 
 int metal_sys_init(const struct metal_init_params *params)
 {
 	metal_bus_register(&metal_generic_bus);
-	return metal_irq_init();
+	return 0;
 }
 
 void metal_sys_finish(void)
 {
-	metal_irq_deinit();
 	metal_bus_unregister(&metal_generic_bus);
 }

--- a/lib/system/zephyr/irq.c
+++ b/lib/system/zephyr/irq.c
@@ -41,7 +41,10 @@ struct metal_irqs_state {
 	metal_mutex_t irq_lock;   /**< access lock */
 };
 
-static struct metal_irqs_state _irqs;
+static struct metal_irqs_state _irqs = {
+	.irqs = METAL_INIT_LIST(_irqs.irqs),
+	.irq_lock = METAL_MUTEX_INIT(_irqs.irq_lock),
+};
 
 int metal_irq_register(int irq,
                        metal_irq_handler hd,
@@ -274,18 +277,4 @@ void metal_irq_isr(unsigned int vector)
 			}
 		}
 	}
-}
-
-int metal_irq_init(void)
-{
-	/* list of interrupt having at least one handler registered */
-	metal_list_init(&_irqs.irqs);
-	/* mutex to manage concurrent access to shared irq data */
-	metal_mutex_init(&_irqs.irq_lock);
-	return 0;
-}
-
-void metal_irq_deinit(void)
-{
-	metal_mutex_deinit(&_irqs.irq_lock);
 }

--- a/lib/system/zephyr/mutex.h
+++ b/lib/system/zephyr/mutex.h
@@ -25,6 +25,15 @@ extern "C" {
 
 typedef struct k_sem metal_mutex_t;
 
+/*
+ * METAL_MUTEX_INIT - used for initializing an mutex elmenet in a static struct
+ * or global
+ */
+#define METAL_MUTEX_INIT(m) _K_SEM_INITIALIZER(m, 1, 1)
+/*
+ * METAL_MUTEX_DEFINE - used for defining and initializing a global or
+ * static singleton mutex
+ */
 #define METAL_MUTEX_DEFINE(m) K_SEM_DEFINE(m, 1, 1)
 
 static inline void __metal_mutex_init(metal_mutex_t *m)


### PR DESCRIPTION
Rework how we initialize metal_irqs_state _irqs so we can remove metal_irq_init/metal_irq_deinit and reduce code size when the irq register code isn't used.