### PR TITLE
zephyr: use sys_cache_flush() for flushing caches

### DIFF
--- a/lib/system/zephyr/cache.h
+++ b/lib/system/zephyr/cache.h
@@ -16,6 +16,7 @@
 #ifndef __METAL_ZEPHYR_CACHE__H__
 #define __METAL_ZEPHYR_CACHE__H__
 
+#include <cache.h>
 #include <metal/utilities.h>
 
 #ifdef __cplusplus
@@ -24,9 +25,7 @@ extern "C" {
 
 static inline void __metal_cache_flush(void *addr, unsigned int len)
 {
-	metal_unused(addr);
-	metal_unused(len);
-	return;
+	sys_cache_flush((vaddr_t) addr, len);
 }
 
 static inline void __metal_cache_invalidate(void *addr, unsigned int len)


### PR DESCRIPTION
Implements the __metal_cache_flush() function as a call to Zephyr's
sys_cache_flush() function.

Signed-off-by: Kristian Klomsten Skordal <kristian.skordal@nordicsemi.no>