### PR TITLE
io: no default I/O block operations

### DIFF
--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/sys_init.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/sys_init.c
@@ -99,7 +99,17 @@ static struct metal_device metal_dev_table[] = {
 				.page_mask = DEFAULT_PAGE_MASK,
 				.mem_flags = NORM_SHARED_NCACHE |
 						PRIV_RW_USER_RW,
-				.ops = {NULL},
+				.ops = {
+					.read = NULL,
+					.write = NULL,
+					.block_read =
+					metal_io_normal_mem_block_read,
+					.block_write =
+					metal_io_normal_mem_block_write,
+					.block_set =
+					metal_io_normal_mem_block_set,
+					.close = NULL,
+				},
 			}
 		},
 		.node = {NULL},

--- a/lib/io.h
+++ b/lib/io.h
@@ -78,6 +78,9 @@ struct metal_io_region {
 	struct metal_io_ops	ops;        /**< I/O region operations */
 };
 
+extern struct metal_io_ops metal_io_device_block_mem_ops;
+extern struct metal_io_ops metal_io_normal_mem_ops;
+
 /**
  * @brief	Open a libmetal I/O region.
  *
@@ -348,6 +351,36 @@ int metal_io_block_write(struct metal_io_region *io, unsigned long offset,
 int metal_io_block_set(struct metal_io_region *io, unsigned long offset,
 	       unsigned char value, int len);
 
+int metal_io_normal_mem_block_read(struct metal_io_region *io,
+					 unsigned long offset,
+					 void *restrict dst,
+					 memory_order order,
+					 int len);
+int metal_io_normal_mem_block_write(struct metal_io_region *io,
+					   unsigned long offset,
+					   const void *restrict src,
+					   memory_order order,
+					   int len);
+void metal_io_normal_mem_block_set(struct metal_io_region *io,
+					  unsigned long offset,
+					  unsigned char value,
+					  memory_order order,
+					  int len);
+int metal_io_device_mem_block_read(struct metal_io_region *io,
+					 unsigned long offset,
+					 void *restrict dst,
+					 memory_order order,
+					 int len);
+int metal_io_device_mem_block_write(struct metal_io_region *io,
+					   unsigned long offset,
+					   const void *restrict src,
+					   memory_order order,
+					   int len);
+void metal_io_device_mem_block_set(struct metal_io_region *io,
+					  unsigned long offset,
+					  unsigned char value,
+					  memory_order order,
+					  int len);
 #include <metal/system/@PROJECT_SYSTEM@/io.h>
 
 /** @} */

--- a/lib/system/linux/device.c
+++ b/lib/system/linux/device.c
@@ -234,7 +234,8 @@ static int metal_uio_dev_open(struct linux_bus *lbus, struct linux_device *ldev)
 			 metal_map(ldev->fd, offset, size, 0, 0, &virt));
 		if (!result) {
 			io = &ldev->device.regions[ldev->device.num_regions];
-			metal_io_init(io, virt, phys, size, -1, 0, NULL);
+			metal_io_init(io, virt, phys, size, -1, 0,
+				      &metal_io_device_block_mem_ops);
 			ldev->device.num_regions++;
 		}
 	}

--- a/lib/system/linux/shmem.c
+++ b/lib/system/linux/shmem.c
@@ -25,7 +25,12 @@ static void metal_shmem_io_close(struct metal_io_region *io)
 }
 
 static const struct metal_io_ops metal_shmem_io_ops = {
-	NULL, NULL, NULL, NULL, NULL, metal_shmem_io_close
+	.read = NULL,
+	.write = NULL,
+	.block_read = metal_io_normal_mem_block_read,
+	.block_write = metal_io_normal_mem_block_write,
+	.block_set = metal_io_normal_mem_block_set,
+	.close = metal_shmem_io_close,
 };
 
 static int metal_shmem_try_map(struct metal_page_size *ps, int fd, size_t size,


### PR DESCRIPTION
Don't provide default I/O block operations system or user application
will need to specify I/O block operations if it is required.

Signed-off-by: Wendy Liang <jliang@xilinx.com>