### PR TITLE
cmake: Make it easier to include libmetal in another cmake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,12 @@
 cmake_minimum_required (VERSION 2.6)
+if (POLICY CMP0048)
+  cmake_policy(SET CMP0048 NEW)
+endif()
 
 list (APPEND CMAKE_MODULE_PATH
-      "${CMAKE_SOURCE_DIR}/cmake"
-      "${CMAKE_SOURCE_DIR}/cmake/modules"
-      "${CMAKE_SOURCE_DIR}/cmake/platforms")
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/platforms")
 
 include (syscheck)
 project (metal C)


### PR DESCRIPTION
If we include libmetal as part of a larger cmake project we should have
project set already so we need to set cmake policy CMP0048.

Also, we should use CMAKE_CURRENT_SOURCE_DIR instead of
CMAKE_SOURCE_DIR.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>