### PR TITLE
cmake: Only look for doxygen package if docs enabled

### DIFF
--- a/cmake/depends.cmake
+++ b/cmake/depends.cmake
@@ -1,4 +1,6 @@
-find_package (Doxygen)
+if (WITH_DOC)
+  find_package (Doxygen)
+endif (WITH_DOC)
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
 


### PR DESCRIPTION
Add an if (WITH_DOCS) wrapper around find_package(Doxygen).  We only
need Doxygen if we are trying to build the docs.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>