### PR TITLE
compiler: add IAR compiler file

### DIFF
--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -14,6 +14,8 @@
 
 #if defined(__GNUC__)
 # include <metal/compiler/gcc/compiler.h>
+#elif defined(__ICCARM__)
+# include <metal/compiler/iar/compiler.h>
 #else
 # error "Missing compiler support"
 #endif

--- a/lib/compiler/CMakeLists.txt
+++ b/lib/compiler/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory (gcc)
+add_subdirectory (iar)
 
 # vim: expandtab:ts=2:sw=2:smartindent

--- a/lib/compiler/iar/CMakeLists.txt
+++ b/lib/compiler/iar/CMakeLists.txt
@@ -1,0 +1,3 @@
+collect (PROJECT_LIB_HEADERS compiler.h)
+
+# vim: expandtab:ts=2:sw=2:smartindent

--- a/lib/compiler/iar/compiler.h
+++ b/lib/compiler/iar/compiler.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018, ST Microelectronics. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	iar/compiler.h
+ * @brief	IAR specific primitives for libmetal.
+ */
+
+#ifndef __METAL_IAR_COMPILER__H__
+#define __METAL_IAR_COMPILER__H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define restrict __restrict__
+#define metal_align(n) __attribute__((aligned(n)))
+#define metal_weak __attribute__((weak))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_IAR_COMPILER__H__ */


### PR DESCRIPTION
Add IAR support in compiler.h. Add associated iar folder.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>