### PR TITLE
libmetal: Add API to read device tree property

### DIFF
--- a/lib/system/linux/device.c
+++ b/lib/system/linux/device.c
@@ -636,3 +636,32 @@ int metal_generic_dev_sys_open(struct metal_device *dev)
 	return 0;
 }
 
+/**
+ * @brief	Read device tree property from sys filesystem.
+ * @param[in]	device	metal_device of the intended DT node
+ * @param[in]	property_name	name of the property to be read
+ * @param[out]	output	output buffer to store read data
+ * @param[in]	len	number of bytes to be read
+ * @return	0 on success, or -errno on error.
+ */
+
+int metal_linux_get_device_property(struct metal_device *device,
+		const char *property_name, void *output, int len)
+{
+	int fd = 0;
+	int status = 0;
+	const int flags = O_RDONLY;
+	const int mode = S_IRUSR | S_IRGRP | S_IROTH;
+	struct linux_device *ldev = to_linux_device(device);
+	char path[PATH_MAX];
+
+	snprintf(path, sizeof(path), "%s/of_node/%s",
+			 ldev->sdev->path, property_name);
+	fd = open(path, flags, mode);
+	if (fd < 0)
+		return -errno;
+	status = read(fd, output, len);
+
+	return status < 0 ? -errno : 0;
+}
+

--- a/lib/system/linux/sys.h
+++ b/lib/system/linux/sys.h
@@ -46,6 +46,8 @@ extern "C" {
 #define METAL_INVALID_VADDR     NULL
 #define MAX_PAGE_SIZES		32
 
+struct metal_device;
+
 /** Structure of shared page or hugepage sized data. */
 struct metal_page_size {
 	/** Page size. */
@@ -110,6 +112,9 @@ extern void metal_randomize_string(char *template);
 extern void metal_mktemp_template(char template[PATH_MAX],
 				  const char *name);
 extern int metal_virt2phys(void *addr, unsigned long *phys);
+
+extern int metal_linux_get_device_property(struct metal_device *device,
+	  const char *property_name, void *output, int len);
 
 #define metal_for_each_page_size_up(ps)					\
 	for ((ps) = &_metal.page_sizes[0];				\


### PR DESCRIPTION
Added new API "metal_linux_get_device_property" to read
device tree property from Linux user space.