### PR TITLE
cmake: Fix Zephyr library integration

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -63,7 +63,7 @@ endif (WITH_DEFAULT_LOGGER)
 if (WITH_ZEPHYR)
   zephyr_library_named(metal)
   add_dependencies(metal offsets_h)
-  target_sources (metal PRIVATE ${_sources})
+  zephyr_library_sources(${_sources})
   zephyr_include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 else (WITH_ZEPHYR)
   # Build a shared library if so configured.


### PR DESCRIPTION
When trying to build libmetal as a library with Zephyr we should use
zephyr_library_sources instead of target_sources.  This issue shows up
because of a fix in Zephyr post the 1.12.0 release.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>