### PR TITLE
ci: Zephyr env var for toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ dist: trusty
 
 env:
   global:
-    - ZEPHYR_GCC_VARIANT=zephyr
+    - ZEPHYR_TOOLCHAIN_VARIANT=zephyr
     - ZEPHYR_SDK_INSTALL_DIR=/opt/zephyr-sdk
     - ZEPHYR_BASE=$TRAVIS_BUILD_DIR/deps/zephyr
     - ZEPHYR_SDK_VERSION=0.9.3


### PR DESCRIPTION
Zephyr has deprecated the environment variable ZEPHYR_GCC_VARIANT and
replaced it with ZEPHYR_TOOLCHAIN_VARIANT.  Match this change.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>