### PR TITLE
linux: device: Add the uio_dmem_genirq driver

### DIFF
--- a/lib/system/linux/device.c
+++ b/lib/system/linux/device.c
@@ -368,6 +368,16 @@ static struct linux_bus linux_bus[] = {
 				.dev_dma_map = metal_uio_dev_dma_map,
 				.dev_dma_unmap = metal_uio_dev_dma_unmap,
 			},
+			{
+				.drv_name  = "uio_dmem_genirq",
+				.mod_name  = "uio_dmem_genirq",
+				.cls_name  = "uio",
+				.dev_open  = metal_uio_dev_open,
+				.dev_close = metal_uio_dev_close,
+				.dev_irq_ack  = metal_uio_dev_irq_ack,
+				.dev_dma_map = metal_uio_dev_dma_map,
+				.dev_dma_unmap = metal_uio_dev_dma_unmap,
+			},
 			{ 0 /* sentinel */ }
 		}
 	},

--- a/lib/system/linux/device.c
+++ b/lib/system/linux/device.c
@@ -102,7 +102,7 @@ static int metal_uio_dev_bind(struct linux_device *ldev,
 		return 0;
 
 	if (strcmp(ldev->sdev->driver_name, SYSFS_UNKNOWN) != 0) {
-		metal_log(METAL_LOG_ERROR, "device %s in use by driver %s\n",
+		metal_log(METAL_LOG_INFO, "device %s in use by driver %s\n",
 			  ldev->dev_name, ldev->sdev->driver_name);
 		return -EBUSY;
 	}


### PR DESCRIPTION
The Linux UIO dmem driver allows the dma memory allocation for clients.
Add the support for the UIO dmem driver.

Signed-off-by: Hyun Kwon <hyun.kwon@xilinx.com>