### PR TITLE
zynqmp_a53: Convert '&' to '&&' operator in if statement

### DIFF
--- a/lib/system/freertos/zynqmp_a53/sys.c
+++ b/lib/system/freertos/zynqmp_a53/sys.c
@@ -39,7 +39,7 @@ unsigned int sys_irq_save_disable(void)
 
 void metal_machine_cache_flush(void *addr, unsigned int len)
 {
-	if (!addr & !len)
+	if (!addr && !len)
 		Xil_DCacheFlush();
 	else
 		Xil_DCacheFlushRange((intptr_t)addr, len);
@@ -47,7 +47,7 @@ void metal_machine_cache_flush(void *addr, unsigned int len)
 
 void metal_machine_cache_invalidate(void *addr, unsigned int len)
 {
-	if (!addr & !len)
+	if (!addr && !len)
 		Xil_DCacheInvalidate();
 	else
 		Xil_DCacheInvalidateRange((intptr_t)addr, len);

--- a/lib/system/generic/zynqmp_a53/sys.c
+++ b/lib/system/generic/zynqmp_a53/sys.c
@@ -39,7 +39,7 @@ unsigned int sys_irq_save_disable(void)
 
 void metal_machine_cache_flush(void *addr, unsigned int len)
 {
-	if (!addr & !len)
+	if (!addr && !len)
 		Xil_DCacheFlush();
 	else
 		Xil_DCacheFlushRange((intptr_t)addr, len);
@@ -47,7 +47,7 @@ void metal_machine_cache_flush(void *addr, unsigned int len)
 
 void metal_machine_cache_invalidate(void *addr, unsigned int len)
 {
-	if (!addr & !len)
+	if (!addr && !len)
 		Xil_DCacheInvalidate();
 	else
 		Xil_DCacheInvalidateRange((intptr_t)addr, len);


### PR DESCRIPTION
Fix incorrect test in if statement by replacing bitwise AND
with logical AND operation.

Found using Coccinelle.

Semantic Patch Language (SmPL) used:

<smpl>

@@
expression E1, E2;
@@

- !E1 & !E2
+ !E1 && !E2

</smpl>

Signed-off-by: Himanshu Jha <himanshujha199640@gmail.com>