### PR TITLE
Use cpp atomic if it is compiled for cpp application

### DIFF
--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -17,6 +17,8 @@
 #if defined(HAVE_STDATOMIC_H) && !defined(__STDC_NO_ATOMICS__) && \
 	!defined(__cplusplus)
 # include <stdatomic.h>
+#elif defined(__cplusplus)
+# include <atomic>
 #elif defined(__GNUC__)
 # include <metal/compiler/gcc/atomic.h>
 #else


### PR DESCRIPTION
Use cpp atomic if it is compiled for cpp application