### PR TITLE
Revert "utilities: restrict the bitmap pointer is aligned"

### DIFF
--- a/lib/utilities.h
+++ b/lib/utilities.h
@@ -78,7 +78,6 @@ extern "C" {
 
 static inline void metal_bitmap_set_bit(unsigned long *bitmap, int bit)
 {
-	bitmap = __builtin_assume_aligned(bitmap, sizeof(unsigned long));
 	bitmap[bit / METAL_BITS_PER_ULONG] |=
 		metal_bit(bit & (METAL_BITS_PER_ULONG - 1));
 }
@@ -91,7 +90,6 @@ static inline int metal_bitmap_is_bit_set(unsigned long *bitmap, int bit)
 
 static inline void metal_bitmap_clear_bit(unsigned long *bitmap, int bit)
 {
-	bitmap = __builtin_assume_aligned(bitmap, sizeof(unsigned long));
 	bitmap[bit / METAL_BITS_PER_ULONG] &=
 		~metal_bit(bit & (METAL_BITS_PER_ULONG - 1));
 }


### PR DESCRIPTION
since no all compiler support __builtin_assume_aligned
This reverts commit 0b979d4cbc9c51044664340539d66862597f3172.

Change-Id: I7c3523b63331917f3a330e08ba4196e1f1534daf