### PR TITLE
xlnx_common: change common isr input arg type

### DIFF
--- a/lib/system/freertos/xlnx_common/irq.c
+++ b/lib/system/freertos/xlnx_common/irq.c
@@ -47,8 +47,11 @@ static METAL_IRQ_CONTROLLER_DECLARE(xlnx_irq_cntr,
 /**
  * @brief default handler
  */
-void metal_xlnx_irq_isr(unsigned int vector)
+void metal_xlnx_irq_isr(void *arg)
 {
+	unsigned int vector;
+
+	vector = (uintptr_t)arg;
 	if (vector >= MAX_IRQS) {
 		return;
 	}

--- a/lib/system/freertos/xlnx_common/sys.h
+++ b/lib/system/freertos/xlnx_common/sys.h
@@ -26,9 +26,9 @@ extern "C" {
  * Xilinx interrupt ISR can be registered to the Xilinx embeddedsw
  * IRQ controller driver.
  *
- * @param[in] vector interrupt vector
+ * @param[in] arg input argument, interrupt vector id.
  */
-void metal_xlnx_irq_isr(unsigned int vector);
+void metal_xlnx_irq_isr(void *arg);
 
 /**
  * @brief	metal_xlnx_irq_int

--- a/lib/system/generic/xlnx_common/irq.c
+++ b/lib/system/generic/xlnx_common/irq.c
@@ -47,9 +47,11 @@ static METAL_IRQ_CONTROLLER_DECLARE(xlnx_irq_cntr,
 /**
  * @brief default handler
  */
-void metal_xlnx_irq_isr(unsigned int vector)
+void metal_xlnx_irq_isr(void *arg)
 {
+	unsigned int vector;
 
+	vector = (uintptr_t)arg;
 	if (vector >= MAX_IRQS) {
 		return;
 	}

--- a/lib/system/generic/xlnx_common/sys.h
+++ b/lib/system/generic/xlnx_common/sys.h
@@ -26,9 +26,9 @@ extern "C" {
  * Xilinx interrupt ISR can be registered to the Xilinx embeddedsw
  * IRQ controller driver.
  *
- * @param[in] vector interrupt vector
+ * @param[in] arg input argument, interrupt vector id.
  */
-void metal_xlnx_irq_isr(unsigned int vector);
+void metal_xlnx_irq_isr(void *arg);
 
 /**
  * @brief	metal_xlnx_irq_int


### PR DESCRIPTION
Change the type of the input argument of the Xilinx
common isr to (void *) to meet the Xilinx library
requirement.

Signed-off-by: Wendy Liang <wendy.liang@xilinx.com>