### PR TITLE
Fix atomic operations compilation errors

### DIFF
--- a/examples/system/generic/zynqmp_r5/CMakeLists.txt
+++ b/examples/system/generic/zynqmp_r5/CMakeLists.txt
@@ -5,6 +5,8 @@ collect(PROJECT_LIB_DEPS c)
 collect(PROJECT_LIB_DEPS m)
 
 set (_lib "xil")
+list (APPEND _lib "xilmem")
+list (APPEND _lib "xilstandalone")
 find_library (_lib_path ${_lib})
 if (NOT _lib_path)
   message ( "external library ${_lib_path} not found" )

--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -16,6 +16,7 @@
 
 #if defined(HAVE_STDATOMIC_H) && !defined(__STDC_NO_ATOMICS__) && \
 	!defined(__cplusplus)
+# include <stdint.h>
 # include <stdatomic.h>
 #elif defined(__cplusplus)
 # include <atomic>

--- a/lib/softirq.c
+++ b/lib/softirq.c
@@ -19,8 +19,8 @@
 #define METAL_SOFTIRQ_ARRAY_DECLARE(num) \
 	static const int metal_softirq_num = num; \
 	static struct metal_irq metal_softirqs[num]; \
-	static char metal_softirq_pending[num]; \
-	static char metal_softirq_enabled[num]; \
+	static atomic_char metal_softirq_pending[num]; \
+	static atomic_char metal_softirq_enabled[num]; \
 
 static int metal_softirq_avail = 0;
 METAL_SOFTIRQ_ARRAY_DECLARE(METAL_SOFTIRQ_NUM)

--- a/lib/spinlock.h
+++ b/lib/spinlock.h
@@ -22,11 +22,11 @@ extern "C" {
 /** \defgroup spinlock Spinlock Interfaces
  *  @{ */
 struct metal_spinlock {
-	atomic_int v;
+	atomic_flag v;
 };
 
 /** Static metal spinlock initialization. */
-#define METAL_SPINLOCK_INIT		{ATOMIC_VAR_INIT(0)}
+#define METAL_SPINLOCK_INIT		{ATOMIC_FLAG_INIT}
 
 /**
  * @brief	Initialize a libmetal spinlock.
@@ -34,7 +34,7 @@ struct metal_spinlock {
  */
 static inline void metal_spinlock_init(struct metal_spinlock *slock)
 {
-	atomic_store(&slock->v, 0);
+	atomic_flag_clear(&slock->v);
 }
 
 /**

--- a/lib/system/generic/condition.c
+++ b/lib/system/generic/condition.c
@@ -17,7 +17,7 @@ extern void metal_generic_default_poll(void);
 int metal_condition_wait(struct metal_condition *cv,
 			 metal_mutex_t *m)
 {
-	metal_mutex_t *tmpm = 0;
+	uintptr_t tmpmptr = 0, mptr = (uintptr_t)m;
 	int v;
 	unsigned int flags;
 
@@ -25,8 +25,8 @@ int metal_condition_wait(struct metal_condition *cv,
 	if (!cv || !m || !metal_mutex_is_acquired(m))
 		return -EINVAL;
 
-	if (!atomic_compare_exchange_strong(&cv->m, &tmpm, m)) {
-		if (m != tmpm)
+	if (!atomic_compare_exchange_strong(&cv->mptr, &tmpmptr, mptr)) {
+		if (tmpmptr != mptr)
 			return -EINVAL;
 	}
 

--- a/lib/system/generic/condition.h
+++ b/lib/system/generic/condition.h
@@ -27,21 +27,21 @@ extern "C" {
 #endif
 
 struct metal_condition {
-	metal_mutex_t *m; /**< mutex.
-	                       The condition variable is attached to
-	                       this mutex when it is waiting.
-	                       It is also used to check correctness
-	                       in case there are multiple waiters. */
+	atomic_uintptr_t mptr; /**< mutex pointer.
+				    The condition variable is attached to
+				    this mutex when it is waiting.
+				    It is also used to check correctness
+				    in case there are multiple waiters. */
 
 	atomic_int v; /**< condition variable value. */
 };
 
 /** Static metal condition variable initialization. */
-#define METAL_CONDITION_INIT		{ NULL, ATOMIC_VAR_INIT(0) }
+#define METAL_CONDITION_INIT	{ ATOMIC_VAR_INIT(0), ATOMIC_VAR_INIT(0) }
 
 static inline void metal_condition_init(struct metal_condition *cv)
 {
-	cv->m = NULL;
+	atomic_init(&cv->mptr, 0);
 	atomic_init(&cv->v, 0);
 }
 

--- a/lib/system/linux/condition.c
+++ b/lib/system/linux/condition.c
@@ -14,15 +14,15 @@
 int metal_condition_wait(struct metal_condition *cv,
 				       metal_mutex_t *m)
 {
-	metal_mutex_t *tmpm = 0;
+	uintptr_t tmpmptr = 0, mptr = (uintptr_t)m;
 	int v = 0;
 
 	/* Check if the mutex has been acquired */
 	if (!cv || !m || !metal_mutex_is_acquired(m))
 		return -EINVAL;
 
-	if (!atomic_compare_exchange_strong(&cv->m, &tmpm, m)) {
-		if (m != tmpm)
+	if (!atomic_compare_exchange_strong(&cv->mptr, &tmpmptr, mptr)) {
+		if (tmpmptr != mptr)
 			return -EINVAL;
 	}
 

--- a/lib/system/linux/condition.h
+++ b/lib/system/linux/condition.h
@@ -29,22 +29,23 @@ extern "C" {
 #endif
 
 struct metal_condition {
-	metal_mutex_t *m; /**< mutex.
-	                       The condition variable is attached to
-	                       this mutex when it is waiting.
-	                       It is also used to check correctness
-	                       in case there are multiple waiters. */
+	atomic_uintptr_t mptr; /**< mutex pointer.
+				    The condition variable is attached to
+				    this mutex when it is waiting.
+				    It is also used to check correctness
+				    in case there are multiple waiters. */
 
 	atomic_int waiters;    /**< number of waiters. */
 	atomic_int wakeups;    /**< number of wakeups. */
 };
 
 /** Static metal condition variable initialization. */
-#define METAL_CONDITION_INIT		{ NULL, ATOMIC_VAR_INIT(0), ATOMIC_VAR_INIT(0) }
+#define METAL_CONDITION_INIT	{ ATOMIC_VAR_INIT(0), ATOMIC_VAR_INIT(0), \
+				  ATOMIC_VAR_INIT(0) }
 
 static inline void metal_condition_init(struct metal_condition *cv)
 {
-	cv->m = NULL;
+	atomic_init(&cv->mptr, 0);
 	atomic_init(&cv->waiters, 0);
 	atomic_init(&cv->wakeups, 0);
 }

--- a/lib/system/zephyr/condition.c
+++ b/lib/system/zephyr/condition.c
@@ -17,17 +17,19 @@ extern void metal_generic_default_poll(void);
 int metal_condition_wait(struct metal_condition *cv,
 			 metal_mutex_t *m)
 {
-	metal_mutex_t *tmpm = 0;
+	uintptr_t tmpmptr = 0, mptr = (uintptr_t)m;
 	int v;
 	unsigned int flags;
 
 	/* Check if the mutex has been acquired */
-	if (!cv || !m || !metal_mutex_is_acquired(m))
+	if (!cv || !m || !metal_mutex_is_acquired(m)) {
 		return -EINVAL;
+	}
 
-	if (!atomic_compare_exchange_strong(&cv->m, &tmpm, m)) {
-		if (m != tmpm)
+	if (!atomic_compare_exchange_strong(&cv->mptr, &tmpmptr, mptr)) {
+		if (tmpmptr != mptr) {
 			return -EINVAL;
+		}
 	}
 
 	v = atomic_load(&cv->v);

--- a/lib/system/zephyr/condition.h
+++ b/lib/system/zephyr/condition.h
@@ -26,21 +26,21 @@ extern "C" {
 #endif
 
 struct metal_condition {
-	metal_mutex_t *m; /**< mutex.
-	                       The condition variable is attached to
-	                       this mutex when it is waiting.
-	                       It is also used to check correctness
-	                       in case there are multiple waiters. */
+	atomic_uintptr_t mptr; /**< mutex pointer.
+				    The condition variable is attached to
+				    this mutex when it is waiting.
+				    It is also used to check correctness
+				    in case there are multiple waiters. */
 
 	atomic_int v; /**< condition variable value. */
 };
 
 /** Static metal condition variable initialization. */
-#define METAL_CONDITION_INIT		{ NULL, ATOMIC_VAR_INIT(0) }
+#define METAL_CONDITION_INIT	{ ATOMIC_VAR_INIT(0), ATOMIC_VAR_INIT(0) }
 
 static inline void metal_condition_init(struct metal_condition *cv)
 {
-	cv->m = NULL;
+	atomic_init(&cv->mptr, 0);
 	atomic_init(&cv->v, 0);
 }
 

--- a/test/system/generic/zynqmp_r5/CMakeLists.txt
+++ b/test/system/generic/zynqmp_r5/CMakeLists.txt
@@ -1,6 +1,9 @@
 collect (PROJECT_LIB_TESTS helper.c)
 
 set (_test_lib_external "xil")
+list (APPEND _test_lib_external "xilmem")
+list (APPEND _test_lib_external "xilstandalone")
+
 
 collect (PROJECT_LIB_DEPS ${_test_lib_external})
 collect (PROJECT_LIB_DEPS "c")


### PR DESCRIPTION
These patches fix the places which do not comply with the c11 atomic operations specification.