### PR TITLE
irq: zephyr: Restore implementations of metal_irq functions

### DIFF
--- a/lib/system/zephyr/irq.c
+++ b/lib/system/zephyr/irq.c
@@ -20,11 +20,11 @@
 
 unsigned int metal_irq_save_disable(void)
 {
-	return sys_irq_save_disable();
+	return irq_lock();
 }
 
 void metal_irq_restore_enable(unsigned int flags)
 {
-	sys_irq_restore_enable(flags);
+	irq_unlock(flags);
 }
 


### PR DESCRIPTION
metal_irq_save_disable and metal_irq_restore_enable to utilize the
Zephyr irq_lock & irq_unlock function.  While we don't have libmetal IRQ
support for Zephyr, using irq_lock/irq_unlock makes the most sense for
now and fixes build warnings since there aren't any implementations of
sys_irq_save_disable/sys_irq_restore_enable for Zephyr builds.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>