### PR TITLE
softirq: use atomic load to check if irq is enabled.

### DIFF
--- a/lib/softirq.c
+++ b/lib/softirq.c
@@ -90,7 +90,7 @@ void metal_softirq_dispatch()
 		struct metal_irq *irq;
 		char is_pending = 1;
 
-		if (metal_softirq_enabled[i] != 0 &&
+		if (atomic_load(&metal_softirq_enabled[i]) != 0 &&
 		    atomic_compare_exchange_strong(&metal_softirq_pending[i],
 						   &is_pending, 0)) {
 			irq = &metal_softirqs[i];


### PR DESCRIPTION
Use atomic load to check if IRQ is enabled. For some compiler,
It is not allow to directly compare atomic type variable with
variables of other types.

Signed-off-by: Wendy Liang <wendy.liang@xilinx.com>