### PR TITLE
examples: fixed include to make libmetal compile with TCLIBC=musl

### DIFF
--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_throughput_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_throughput_demo.c
@@ -41,7 +41,7 @@
  */
 
 #include <unistd.h>
-#include <error.h>
+#include <errno.h>
 #include <metal/atomic.h>
 #include <metal/io.h>
 #include <metal/device.h>


### PR DESCRIPTION
Inclusion of error.h in example shmem_throughput_demo.c leads to
build failure when using musl instead of glibc as C library.
The file does not use any error.h specific functions, only the
error codes which are defined in errno.h. So the include can be
changed to errno.h.

Signed-off-by: Joerg Hofrichter <joerg.hofrichter@ni.com>