### PR TITLE
lib: arm CM33: Add Cortex M33 support

### DIFF
--- a/cmake/platforms/arm-cm33-generic.cmake
+++ b/cmake/platforms/arm-cm33-generic.cmake
@@ -1,0 +1,9 @@
+set (CMAKE_SYSTEM_PROCESSOR "arm"            CACHE STRING "")
+set (MACHINE                "arm_cm33"          CACHE STRING "")
+set (CROSS_PREFIX           "arm-none-eabi-" CACHE STRING "")
+
+set (CMAKE_C_FLAGS          "-mcpu=cortex-m33+nodsp " CACHE STRING "")
+
+include (cross-generic-gcc)
+
+# vim: expandtab:ts=2:sw=2:smartindent

--- a/lib/system/generic/arm_cm33/CMakeLists.txt
+++ b/lib/system/generic/arm_cm33/CMakeLists.txt
@@ -1,0 +1,5 @@
+collect (PROJECT_LIB_HEADERS sys.h)
+
+collect (PROJECT_LIB_SOURCES sys.c)
+
+# vim: expandtab:ts=2:sw=2:smartindent

--- a/lib/system/generic/arm_cm33/sys.c
+++ b/lib/system/generic/arm_cm33/sys.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2018-2019, Linaro Inc. and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	generic/arm_cm33/sys.c
+ * @brief	machine specific system primitives implementation.
+ */
+
+#include <metal/io.h>
+#include <metal/sys.h>
+#include <metal/utilities.h>
+#include <stdint.h>
+
+void sys_irq_restore_enable(unsigned int flags)
+{
+	metal_unused(flags);
+	/* Add implementation here */
+}
+
+unsigned int sys_irq_save_disable(void)
+{
+	return 0;
+	/* Add implementation here */
+}
+
+void sys_irq_enable(unsigned int vector)
+{
+	metal_unused(vector);
+
+	/* Add implementation here */
+}
+
+void sys_irq_disable(unsigned int vector)
+{
+	metal_unused(vector);
+
+	/* Add implementation here */
+}
+
+void metal_machine_cache_flush(void *addr, unsigned int len)
+{
+	metal_unused(addr);
+	metal_unused(len);
+
+	/* Add implementation here */
+}
+
+void metal_machine_cache_invalidate(void *addr, unsigned int len)
+{
+	metal_unused(addr);
+	metal_unused(len);
+
+	/* Add implementation here */
+}
+
+void metal_generic_default_poll(void)
+{
+	/* Add implementation here */
+}
+
+void *metal_machine_io_mem_map(void *va, metal_phys_addr_t pa,
+			       size_t size, unsigned int flags)
+{
+	metal_unused(pa);
+	metal_unused(size);
+	metal_unused(flags);
+
+	/* Add implementation here */
+
+	return va;
+}

--- a/lib/system/generic/arm_cm33/sys.h
+++ b/lib/system/generic/arm_cm33/sys.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018-2019, Linaro Inc. and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	generic/arm_cm33/sys.h
+ * @brief	generic system primitives for libmetal.
+ */
+
+#ifndef __METAL_GENERIC_SYS__H__
+#error "Include metal/sys.h instead of metal/generic/@PROJECT_MACHINE@/sys.h"
+#endif
+
+#ifndef __METAL_GENERIC_TEMPLATE_SYS__H__
+#define __METAL_GENERIC_TEMPLATE_SYS__H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef METAL_INTERNAL
+
+void sys_irq_enable(unsigned int vector);
+
+void sys_irq_disable(unsigned int vector);
+
+#endif /* METAL_INTERNAL */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_GENERIC_TEMPLATE_SYS__H__ */


### PR DESCRIPTION
TFM (Trusted Firmware for M class) is a trusted firmware running on arm M
series core to provided security functions.

This patch aims to add support TFM build libmetal.

Signed-off-by: Karl Zhang <karl.zhang@linaro.org>