### PR TITLE
Revert "Use cpp atomic if it is compiled for cpp application"

### DIFF
--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -18,8 +18,6 @@
 	!defined(__cplusplus)
 # include <stdint.h>
 # include <stdatomic.h>
-#elif defined(__cplusplus)
-# include <atomic>
 #elif defined(__GNUC__)
 # include <metal/compiler/gcc/atomic.h>
 #else


### PR DESCRIPTION
Reverts OpenAMP/libmetal#75  as it caused problems compiling with C++ as mentioned in issue #97. 