### PR TITLE
Fix C++ compilation errors on atomic types

### DIFF
--- a/lib/alloc.h
+++ b/lib/alloc.h
@@ -31,7 +31,7 @@ static inline void *metal_allocate_memory(unsigned int size);
 /**
  * @brief      free the memory previously allocated
  *
- * @param[in]  ptr       pointer to memory 
+ * @param[in]  ptr       pointer to memory
  */
 static inline void metal_free_memory(void *ptr);
 

--- a/lib/alloc.h
+++ b/lib/alloc.h
@@ -35,12 +35,12 @@ static inline void *metal_allocate_memory(unsigned int size);
  */
 static inline void metal_free_memory(void *ptr);
 
-#include <metal/system/@PROJECT_SYSTEM@/alloc.h>
-
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include <metal/system/@PROJECT_SYSTEM@/alloc.h>
 
 #endif /* __METAL_ALLOC__H__ */

--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -20,6 +20,15 @@
 # include <stdatomic.h>
 #elif defined(__cplusplus)
 # include <atomic>
+# define _Atomic(T) std::atomic<T>
+using std::memory_order;
+using std::atomic_flag;
+using std::atomic_bool;
+using std::atomic_uchar;
+using std::atomic_ushort;
+using std::atomic_uint;
+using std::atomic_ulong;
+using std::atomic_ullong;
 #elif defined(__GNUC__)
 # include <metal/compiler/gcc/atomic.h>
 #else

--- a/lib/condition.h
+++ b/lib/condition.h
@@ -62,12 +62,12 @@ static inline int metal_condition_broadcast(struct metal_condition *cv);
  */
 int metal_condition_wait(struct metal_condition *cv, metal_mutex_t *m);
 
-#include <metal/system/@PROJECT_SYSTEM@/condition.h>
-
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include <metal/system/@PROJECT_SYSTEM@/condition.h>
 
 #endif /* __METAL_CONDITION__H__ */

--- a/lib/dma.h
+++ b/lib/dma.h
@@ -12,15 +12,15 @@
 #ifndef __METAL_DMA__H__
 #define __METAL_DMA__H__
 
+#include <stdint.h>
+#include <metal/sys.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /** \defgroup dma DMA Interfaces
  *  @{ */
-
-#include <stdint.h>
-#include <metal/sys.h>
 
 #define METAL_DMA_DEV_R  1 /**< DMA direction, device read */
 #define METAL_DMA_DEV_W  2 /**< DMA direction, device write */

--- a/lib/io.h
+++ b/lib/io.h
@@ -356,12 +356,12 @@ int metal_io_block_write(struct metal_io_region *io, unsigned long offset,
 int metal_io_block_set(struct metal_io_region *io, unsigned long offset,
 	       unsigned char value, int len);
 
-#include <metal/system/@PROJECT_SYSTEM@/io.h>
-
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include <metal/system/@PROJECT_SYSTEM@/io.h>
 
 #endif /* __METAL_IO__H__ */

--- a/lib/io.h
+++ b/lib/io.h
@@ -272,16 +272,16 @@ metal_io_write(struct metal_io_region *io, unsigned long offset,
 	if (io->ops.write)
 		(*io->ops.write)(io, offset, value, order, width);
 	else if (ptr && sizeof(atomic_uchar) == width)
-		atomic_store_explicit((atomic_uchar *)ptr, value, order);
+		atomic_store_explicit((atomic_uchar *)ptr, (unsigned char) value, order);
 	else if (ptr && sizeof(atomic_ushort) == width)
-		atomic_store_explicit((atomic_ushort *)ptr, value, order);
+		atomic_store_explicit((atomic_ushort *)ptr, (unsigned short) value, order);
 	else if (ptr && sizeof(atomic_uint) == width)
-		atomic_store_explicit((atomic_uint *)ptr, value, order);
+		atomic_store_explicit((atomic_uint *)ptr, (unsigned int) value, order);
 	else if (ptr && sizeof(atomic_ulong) == width)
-		atomic_store_explicit((atomic_ulong *)ptr, value, order);
+		atomic_store_explicit((atomic_ulong *)ptr, (unsigned long) value, order);
 #ifndef NO_ATOMIC_64_SUPPORT
 	else if (ptr && sizeof(atomic_ullong) == width)
-		atomic_store_explicit((atomic_ullong *)ptr, value, order);
+		atomic_store_explicit((atomic_ullong *)ptr, (unsigned long long) value, order);
 #endif
 	else
 		metal_assert (0);

--- a/lib/irq.h
+++ b/lib/irq.h
@@ -12,15 +12,15 @@
 #ifndef __METAL_IRQ__H__
 #define __METAL_IRQ__H__
 
+#include <metal/list.h>
+#include <stdlib.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /** \defgroup irq Interrupt Handling Interfaces
  *  @{ */
-
-#include <metal/list.h>
-#include <stdlib.h>
 
 /** IRQ handled status */
 #define METAL_IRQ_NOT_HANDLED 0
@@ -92,12 +92,12 @@ void metal_irq_enable(unsigned int vector);
  */
 void metal_irq_disable(unsigned int vector);
 
-#include <metal/system/@PROJECT_SYSTEM@/irq.h>
-
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include <metal/system/@PROJECT_SYSTEM@/irq.h>
 
 #endif /* __METAL_IRQ__H__ */

--- a/lib/irq_controller.h
+++ b/lib/irq_controller.h
@@ -12,16 +12,16 @@
 #ifndef __METAL_IRQ_CONTROLLER__H__
 #define __METAL_IRQ_CONTROLLER__H__
 
+#include <metal/irq.h>
+#include <metal/list.h>
+#include <stdlib.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /** \defgroup irq Interrupt Handling Interfaces
  *  @{ */
-
-#include <metal/irq.h>
-#include <metal/list.h>
-#include <stdlib.h>
 
 /** IRQ ANY ID */
 #define METAL_IRQ_ANY         (-1)

--- a/lib/list.h
+++ b/lib/list.h
@@ -93,6 +93,7 @@ static inline struct metal_list *metal_list_first(struct metal_list *list)
 	for ((node) = (list)->next;		\
 	     (node) != (list);			\
 	     (node) = (node)->next)
+
 /** @} */
 
 #ifdef __cplusplus

--- a/lib/mutex.h
+++ b/lib/mutex.h
@@ -40,7 +40,7 @@ static inline void metal_mutex_deinit(metal_mutex_t *mutex)
 }
 
 /**
- * @brief	Try to acquire a mutex 
+ * @brief	Try to acquire a mutex
  * @param[in]	mutex	Mutex to mutex.
  * @return	0 on failure to acquire, non-zero on success.
  */
@@ -50,7 +50,7 @@ static inline int metal_mutex_try_acquire(metal_mutex_t *mutex)
 }
 
 /**
- * @brief	Acquire a mutex 
+ * @brief	Acquire a mutex
  * @param[in]	mutex	Mutex to mutex.
  */
 static inline void metal_mutex_acquire(metal_mutex_t *mutex)

--- a/lib/mutex.h
+++ b/lib/mutex.h
@@ -12,14 +12,14 @@
 #ifndef __METAL_MUTEX__H__
 #define __METAL_MUTEX__H__
 
+#include <metal/system/@PROJECT_SYSTEM@/mutex.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /** \defgroup mutex Mutex Interfaces
  *  @{ */
-
-#include <metal/system/@PROJECT_SYSTEM@/mutex.h>
 
 /**
  * @brief	Initialize a libmetal mutex.

--- a/lib/softirq.h
+++ b/lib/softirq.h
@@ -12,14 +12,14 @@
 #ifndef __METAL_SOFTIRQ__H__
 #define __METAL_SOFTIRQ__H__
 
+#include <metal/irq.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /** \defgroup soft irq Interrupt Handling Interfaces
  *  @{ */
-
-#include <metal/irq.h>
 
 /**
  * @brief	metal_softirq_init

--- a/lib/system/freertos/alloc.h
+++ b/lib/system/freertos/alloc.h
@@ -16,7 +16,7 @@
 #ifndef __METAL_FREERTOS_ALLOC__H__
 #define __METAL_FREERTOS_ALLOC__H__
 
-#include "FreeRTOS.h"
+#include <FreeRTOS.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/system/generic/mutex.h
+++ b/lib/system/generic/mutex.h
@@ -17,7 +17,6 @@
 #define __METAL_GENERIC_MUTEX__H__
 
 #include <metal/atomic.h>
-#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,7 +39,7 @@ typedef struct {
 
 static inline void __metal_mutex_init(metal_mutex_t *mutex)
 {
-	atomic_store((atomic_bool *)&mutex->v, false);
+	atomic_flag_clear(&mutex->v);
 }
 
 static inline void __metal_mutex_deinit(metal_mutex_t *mutex)

--- a/lib/system/generic/mutex.h
+++ b/lib/system/generic/mutex.h
@@ -17,13 +17,14 @@
 #define __METAL_GENERIC_MUTEX__H__
 
 #include <metal/atomic.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct {
-	atomic_int v;
+	atomic_flag v;
 } metal_mutex_t;
 
 /*
@@ -39,7 +40,7 @@ typedef struct {
 
 static inline void __metal_mutex_init(metal_mutex_t *mutex)
 {
-	atomic_store(&mutex->v, 0);
+	atomic_store((atomic_bool *)&mutex->v, false);
 }
 
 static inline void __metal_mutex_deinit(metal_mutex_t *mutex)
@@ -66,7 +67,7 @@ static inline void __metal_mutex_release(metal_mutex_t *mutex)
 
 static inline int __metal_mutex_is_acquired(metal_mutex_t *mutex)
 {
-	return atomic_load(&mutex->v);
+	return atomic_load((atomic_bool *)&mutex->v);
 }
 
 #ifdef __cplusplus

--- a/lib/time.h
+++ b/lib/time.h
@@ -12,15 +12,15 @@
 #ifndef __METAL_TIME__H__
 #define __METAL_TIME__H__
 
+#include <stdint.h>
+#include <metal/sys.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /** \defgroup time TIME Interfaces
  *  @{ */
-
-#include <stdint.h>
-#include <metal/sys.h>
 
 /**
  * @brief      get timestamp


### PR DESCRIPTION
Includes were moved out from of `extern "C"` blocks. This is discouraged practice as the block also applies on included header and was affecting the include of `<atomic>` header in [lib/atomic.h](https://github.com/OpenAMP/libmetal/blob/edb1c31155839de022e33a74b48914b5575a9047/lib/atomic.h#L22) and causing errors.

Following the instructions in [P0943R0: Support C atomics in C++](http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2018/p0943r0.html), imports were added to make types compatible with `<stdatomic.h>`.

[metal_mutex_t](https://github.com/OpenAMP/libmetal/blob/edb1c31155839de022e33a74b48914b5575a9047/lib/system/generic/mutex.h#L26) was probably meant to use `atomic_flag` as it is used with `atomic_flag_*` functions, but according to C++ [documentation](https://en.cppreference.com/w/cpp/atomic/atomic_flag), `atomic_flag` doesn't provide load and store methods and underlying type is supposed to be boolean, thus cast to `atomic_bool*` seemed appropriate. There has to be a better way to solve this.