### PR TITLE
nuttx: correctly handle the hardware which hasn't the interrupt controller

### DIFF
--- a/lib/system/nuttx/irq.c
+++ b/lib/system/nuttx/irq.c
@@ -28,12 +28,14 @@ void metal_irq_restore_enable(unsigned int flags)
 static void metal_cntr_irq_set_enable(struct metal_irq_controller *cntr,
 				      int irq, unsigned int enable)
 {
+#ifndef CONFIG_ARCH_NOINTC
 	if (irq >= 0 && irq < cntr->irq_num) {
 		if (enable == METAL_IRQ_ENABLE)
 			up_enable_irq(irq);
 		else
 			up_disable_irq(irq);
 	}
+#endif
 }
 
 static int metal_cntr_irq_handler(int irq, void *context, void *data)
@@ -78,7 +80,8 @@ static int metal_cntr_irq_attach(struct metal_irq_controller *cntr,
 int metal_cntr_irq_init(void)
 {
 	static METAL_IRQ_CONTROLLER_DECLARE(metal_cntr_irq,
-					    0, NR_IRQS,
+					    0,
+					    NR_IRQS ? NR_IRQS : 1,
 					    NULL,
 					    metal_cntr_irq_set_enable,
 					    metal_cntr_irq_attach,


### PR DESCRIPTION
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>