### PR TITLE
Change the mailing list to point the OpenAMP Project list.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,18 +8,15 @@ consult when they have a question about OpenAMP and to provide a a set of
 names to be CC'd when submitting a patch.
 
 ## Project Administration
-Wendy Liang <wendy.liang@xilinx.com>
 Ed Mooring <ed.mooring@linaro.org>
 Arnaud Pouliquen <arnaud.pouliquen@st.com>
 
 ### All patches CC here
-open-amp@googlegroups.com
+openamp-rp@lists.openampproject.org
 
 ## Machines
 ### Xilinx Platform - Zynq-7000
-Wendy Liang <wendy.liang@xilinx.com>
 Ed Mooring <ed.mooring@linaro.org>
 
 ### Xilinx Platform - Zynq UltraScale+ MPSoC
-Wendy Liang <wendy.liang@xilinx.com>
 Ed Mooring <ed.mooring@linaro.org>


### PR DESCRIPTION
Change to the new mailing list and remove Wendy as a maintainer.