### PR TITLE
test: fix mlock allocation fail

### DIFF
--- a/test/system/linux/shmem.c
+++ b/test/system/linux/shmem.c
@@ -24,7 +24,7 @@ static void *shmem_child(void *arg)
 	} *virt;
 	struct metal_io_region *io;
 	unsigned long phys;
-	size_t size = 2 * 1024 * 1024;
+	size_t size = 1 * 1024 * 1024;
 	int error;
 
 	error = metal_shmem_open(name, size, &io);


### PR DESCRIPTION
During test we try to lock more memory than the limit
permitted.
This results in following traces:

metal: warning: failed to mlock shmem - Cannot allocate memory
metal: error: pagemap page not present, 3fd7560fd0 -> 80000000000000
metal: error: pagemap page not present, 3fd7560fd8 -> 80000000000000
metal: error: pagemap page not present, 3fd7560fe0 -> 80000000000000
metal: error: pagemap page not present, 3fd7560fe8 -> 80000000000000
[...]

This patch decreases the size of the shem to avoid to reach the limit

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>