### PR TITLE
nuttx: change sched_kfree to kmm_free

### DIFF
--- a/lib/system/nuttx/irq.c
+++ b/lib/system/nuttx/irq.c
@@ -45,7 +45,7 @@ static int metal_cntr_irq_handler(int irq, void *context, void *data)
 
 	/* context == NULL mean unregister */
 	irqchain_detach(irq, metal_cntr_irq_handler, data);
-	sched_kfree(data);
+	metal_free_memory(data);
 	return 0;
 }
 


### PR DESCRIPTION
since the upstream remove sched_kfree and put the similar logic into kmm_free

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>