### PR TITLE
system: Linux: add missing atomic atomic_uintptr_t declaration

### DIFF
--- a/lib/compiler/gcc/atomic.h
+++ b/lib/compiler/gcc/atomic.h
@@ -23,6 +23,7 @@ typedef short atomic_short;
 typedef unsigned short atomic_ushort;
 typedef int atomic_int;
 typedef unsigned int atomic_uint;
+typedef atomic_uint atomic_uintptr_t;
 typedef long atomic_long;
 typedef unsigned long atomic_ulong;
 typedef long long atomic_llong;


### PR DESCRIPTION
Fix compilation issue for condition.c:
atomic_uintptr_t is not declared.
This occurs when the gcc compiler atomic lib is not used.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>