### PR TITLE
system: nuttx: change clock_systimespec to clock_systime_timespec

### DIFF
--- a/lib/system/nuttx/time.c
+++ b/lib/system/nuttx/time.c
@@ -18,7 +18,7 @@ unsigned long long metal_get_timestamp(void)
 	struct timespec tp;
 	int r;
 
-	r = clock_systimespec(&tp);
+	r = clock_systime_timespec(&tp);
 	if (!r) {
 		t = (unsigned long long)tp.tv_sec * NSEC_PER_SEC;
 		t += tp.tv_nsec;


### PR DESCRIPTION
follow up the change from NuttX side:
https://github.com/apache/incubator-nuttx/pull/1022

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>