### PR TITLE
cmake: set the policy CMP0077 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()
 
+if (POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
 list (APPEND CMAKE_MODULE_PATH
       "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
       "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"


### PR DESCRIPTION
This commit introduces CMP0077 and set the policy to new behavior
and thus removes the following warning when using newer CMake versions:
```
Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
--help-policy CMP0077" for policy details.  Use the cmake_policy command
to set the policy and suppress this warning.`
```

Both OLD and NEW behavior will use the value defined earlier in the
CMake process, however the OLD behavior will also add an entry to the
CMakeCache.txt but ignore that value on sub-sequent invocations.
As this may lead to confusion on users looking into the CMakeCache.txt,
then the best is to not get such values into the cache, and thus use NEW
behavior.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>