### PR TITLE
zephyr: Fix metal_get_timestamp implementation

### DIFF
--- a/lib/system/zephyr/time.c
+++ b/lib/system/zephyr/time.c
@@ -10,12 +10,10 @@
  */
 
 #include <metal/time.h>
-#include <sys_clock.h>
-
-extern volatile u64_t _sys_clock_tick_count;
+#include <kernel.h>
 
 unsigned long long metal_get_timestamp(void)
 {
-	return (unsigned long long)_sys_clock_tick_count;
+	return (unsigned long long)k_uptime_ticks();
 }
 


### PR DESCRIPTION
_sys_clock_tick_count has not existed for a number of zephyr releases
(last release was v1.13).  Use k_uptime_ticks() instead to implement
metal_get_timestamp.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>