### PR TITLE
gcc: use __typeof__ instead of typeof in atomic.h

### DIFF
--- a/lib/compiler/gcc/atomic.h
+++ b/lib/compiler/gcc/atomic.h
@@ -63,10 +63,10 @@ typedef enum {
 	atomic_load(OBJ)
 #define atomic_exchange(OBJ, DES)					\
 	({								\
-		typeof(OBJ) obj = (OBJ);				\
-		typeof(*obj) des = (DES);				\
-		typeof(*obj) expval;					\
-		typeof(*obj) oldval = atomic_load(obj);			\
+		__typeof__(OBJ) obj = (OBJ);				\
+		__typeof__(*obj) des = (DES);				\
+		__typeof__(*obj) expval;					\
+		__typeof__(*obj) oldval = atomic_load(obj);			\
 		do {							\
 			expval = oldval;				\
 			oldval = __sync_val_compare_and_swap(		\
@@ -78,10 +78,10 @@ typedef enum {
 	atomic_exchange((OBJ), (DES))
 #define atomic_compare_exchange_strong(OBJ, EXP, DES)			\
 	({								\
-		typeof(OBJ) obj = (OBJ);				\
-		typeof(EXP) exp = (EXP);				\
-		typeof(*obj) expval = *exp;				\
-		typeof(*obj) oldval = __sync_val_compare_and_swap(	\
+		__typeof__(OBJ) obj = (OBJ);				\
+		__typeof__(EXP) exp = (EXP);				\
+		__typeof__(*obj) expval = *exp;				\
+		__typeof__(*obj) oldval = __sync_val_compare_and_swap(	\
 			obj, expval, (DES));				\
 		*exp = oldval;						\
 		oldval == expval;					\


### PR DESCRIPTION
Compiling for Zephyr bails out on typeof. Use \_\_typeof\_\_
which is accepted by gcc regardless of the c language version.

Signed-off-by: Bobby Noelte <b0661n0e17e@gmail.com>