### PR TITLE
[RFC] zephyr: make libmetal a Zephyr module

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -64,42 +64,35 @@ if (WITH_DEFAULT_LOGGER)
   add_definitions (-DDEFAULT_LOGGER_ON)
 endif (WITH_DEFAULT_LOGGER)
 
-if (WITH_ZEPHYR)
-  zephyr_library_named(metal)
-  add_dependencies(metal offsets_h)
-  zephyr_library_sources(${_sources})
-  zephyr_include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
-else (WITH_ZEPHYR)
-  # Build a shared library if so configured.
-  if (WITH_SHARED_LIB)
-    set (_lib ${PROJECT_NAME}-shared)
-    add_library (${_lib} SHARED ${_sources})
-    target_link_libraries (${_lib} ${_deps})
-    install (TARGETS ${_lib} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    if (PROJECT_EC_FLAGS)
-      string(REPLACE " " ";" _ec_flgs ${PROJECT_EC_FLAGS})
-      target_compile_options (${_lib} PUBLIC ${_ec_flgs})
-    endif (PROJECT_EC_FLAGS)
-    set_target_properties (${_lib} PROPERTIES
-      OUTPUT_NAME       "${PROJECT_NAME}"
-      VERSION           "${PROJECT_VER}"
-      SOVERSION         "${PROJECT_VER_MAJOR}"
-    )
-  endif (WITH_SHARED_LIB)
+# Build a shared library if so configured.
+if (WITH_SHARED_LIB)
+  set (_lib ${PROJECT_NAME}-shared)
+  add_library (${_lib} SHARED ${_sources})
+  target_link_libraries (${_lib} ${_deps})
+  install (TARGETS ${_lib} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  if (PROJECT_EC_FLAGS)
+    string(REPLACE " " ";" _ec_flgs ${PROJECT_EC_FLAGS})
+    target_compile_options (${_lib} PUBLIC ${_ec_flgs})
+  endif (PROJECT_EC_FLAGS)
+  set_target_properties (${_lib} PROPERTIES
+    OUTPUT_NAME       "${PROJECT_NAME}"
+    VERSION           "${PROJECT_VER}"
+    SOVERSION         "${PROJECT_VER_MAJOR}"
+  )
+endif (WITH_SHARED_LIB)
 
-  # Build a static library if so configured.
-  if (WITH_STATIC_LIB)
-    set (_lib ${PROJECT_NAME}-static)
-    add_library (${_lib} STATIC ${_sources})
-    install (TARGETS ${_lib} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    if (PROJECT_EC_FLAGS)
-      string(REPLACE " " ";" _ec_flgs ${PROJECT_EC_FLAGS})
-      target_compile_options (${_lib} PUBLIC ${_ec_flgs})
-    endif (PROJECT_EC_FLAGS)
-    set_target_properties (${_lib} PROPERTIES
-      OUTPUT_NAME       "${PROJECT_NAME}"
-    )
-  endif (WITH_STATIC_LIB)
-endif (WITH_ZEPHYR)
+# Build a static library if so configured.
+if (WITH_STATIC_LIB)
+  set (_lib ${PROJECT_NAME}-static)
+  add_library (${_lib} STATIC ${_sources})
+  install (TARGETS ${_lib} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  if (PROJECT_EC_FLAGS)
+    string(REPLACE " " ";" _ec_flgs ${PROJECT_EC_FLAGS})
+    target_compile_options (${_lib} PUBLIC ${_ec_flgs})
+  endif (PROJECT_EC_FLAGS)
+  set_target_properties (${_lib} PROPERTIES
+    OUTPUT_NAME       "${PROJECT_NAME}"
+  )
+endif (WITH_STATIC_LIB)
 
 # vim: expandtab:ts=2:sw=2:smartindent

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Copyright (c) 2020 Bobby Noelte
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Build the OpenAMP libmetal hardware abstraction library as a Zephyr module.
+#
+# Zephyr does have it's own fork of libmetal which is enabled by CONFIG_LIBMETAL.
+
+if (CONFIG_LIBMETAL_BY_OPENAMP)
+
+    # Pathes
+    # ------
+    get_filename_component (LIBMETAL_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
+    get_filename_component (LIBMETAL_DIR_NAME ${LIBMETAL_ROOT_DIR} NAME_WE)
+    set (LIBMETAL_BIN_ROOT "${CMAKE_BINARY_DIR}/modules/${LIBMETAL_DIR_NAME}")
+
+    # Set Zephyr module environment (options)
+    # ---------------------------------------
+    set (PROJECT_NAME "metal")
+    set (CMAKE_SYSTEM_NAME "Generic" CACHE STRING "")
+    string (TOLOWER "Zephyr" PROJECT_SYSTEM)
+    string (TOUPPER "Zephyr" PROJECT_SYSTEM_UPPER)
+    if (CONFIG_CPU_CORTEX_M)
+        set (MACHINE "cortexm" CACHE STRING "")
+    endif (CONFIG_CPU_CORTEX_M)
+
+    # Prevent generation of libraries - we do it on our own
+    set (WITH_SHARED_LIB false)
+    set (WITH_STATIC_LIB false)
+
+    include ("${LIBMETAL_ROOT_DIR}/cmake/options.cmake")
+    include ("${LIBMETAL_ROOT_DIR}/cmake/collect.cmake")
+
+    # Just for info in case somebody needs it
+    set (LIBMETAL_LIB_NAME ${PROJECT_NAME} CACHE STRING "")
+    set (LIBMETAL_VERSION_MAJOR ${PROJECT_VER_MAJOR} CACHE STRING "")
+    set (LIBMETAL_VERSION_MINOR ${PROJECT_VER_MINOR} CACHE STRING "")
+
+    add_subdirectory ("${LIBMETAL_ROOT_DIR}/lib" "${LIBMETAL_BIN_ROOT}/lib")
+
+    # Get collected library information
+    # ---------------------------------
+    collector_list (_sources PROJECT_LIB_SOURCES)
+    foreach (_source ${_sources})
+        if (NOT IS_ABSOLUTE ${_source})
+           set (_source "${LIBMETAL_ROOT_DIR}/lib/${_source}")
+        endif ()
+        list (APPEND LIBMETAL_LIB_SOURCES ${_source})
+    endforeach ()
+
+    # Create the Zephyr library
+    # -------------------------
+    zephyr_library_named(${LIBMETAL_LIB_NAME})
+    add_dependencies(${ZEPHYR_CURRENT_LIBRARY} ${OFFSETS_H_TARGET})
+    zephyr_include_directories("${LIBMETAL_BIN_ROOT}/lib/include")
+    zephyr_library_compile_options("-DMETAL_INTERNAL")
+    zephyr_library_sources(${LIBMETAL_LIB_SOURCES})
+
+endif ()

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 Bobby Noelte
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig LIBMETAL_BY_OPENAMP
+	bool "OpenAMP libmetal HAL"
+	help
+	  Enable the native OpenAMP libmetal hardware abstraction library
+	  (not the Zephyr fork of libmetal).

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+build:
+  cmake: zephyr
+  kconfig: ./zephyr/Kconfig


### PR DESCRIPTION
Allow libmetal to be used as a Zephyr module. This allows easy integration
into Zephyr projects.

OpenAMP libmetal can be used instead of the Zephyr fork. Configuration in
Zephyr is distinct for the two `libmetals`.

Testing has not been adapted - the test knowingly fails.

Making also open-amp a Zephyr module is in my pipeline. I will provide a pull request
to open-amp if this pull request is accepted.

Signed-off-by: Bobby Noelte <b0661n0e17e@gmail.com>