### PR TITLE
Fix mutex implementation for FreeRTOS and Generic

### DIFF
--- a/lib/system/freertos/mutex.h
+++ b/lib/system/freertos/mutex.h
@@ -17,7 +17,6 @@
 #define __METAL_FREERTOS_MUTEX__H__
 
 #include <metal/atomic.h>
-#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,11 +26,14 @@ typedef struct {
 	atomic_int v;
 } metal_mutex_t;
 
+#define METAL_MUTEX_UNLOCKED 0
+#define METAL_MUTEX_LOCKED   1
+
 /*
- * METAL_MUTEX_INIT - used for initializing an mutex elmenet in a static struct
+ * METAL_MUTEX_INIT - used for initializing an mutex element in a static struct
  * or global
  */
-#define METAL_MUTEX_INIT(m)		{ ATOMIC_VAR_INIT(0) }
+#define METAL_MUTEX_INIT(m)	{ ATOMIC_VAR_INIT(METAL_MUTEX_UNLOCKED) }
 /*
  * METAL_MUTEX_DEFINE - used for defining and initializing a global or
  * static singleton mutex
@@ -40,7 +42,7 @@ typedef struct {
 
 static inline void __metal_mutex_init(metal_mutex_t *mutex)
 {
-	atomic_store(&mutex->v, 0);
+	atomic_store(&mutex->v, METAL_MUTEX_UNLOCKED);
 }
 
 static inline void __metal_mutex_deinit(metal_mutex_t *mutex)
@@ -50,19 +52,29 @@ static inline void __metal_mutex_deinit(metal_mutex_t *mutex)
 
 static inline int __metal_mutex_try_acquire(metal_mutex_t *mutex)
 {
-	return 1 - atomic_flag_test_and_set(&mutex->v);
+	int unlocked = METAL_MUTEX_UNLOCKED;
+
+	if (atomic_compare_exchange_strong(&mutex->v, &unlocked,
+					   METAL_MUTEX_LOCKED)) {
+		return 1; /* acquired */
+	} else {
+		return 0; /* not acquired */
+	}
 }
 
 static inline void __metal_mutex_acquire(metal_mutex_t *mutex)
 {
-	while (atomic_flag_test_and_set(&mutex->v)) {
+	int unlocked = METAL_MUTEX_UNLOCKED;
+
+	while (!atomic_compare_exchange_weak(&mutex->v, &unlocked,
+					     METAL_MUTEX_LOCKED)) {
 		;
 	}
 }
 
 static inline void __metal_mutex_release(metal_mutex_t *mutex)
 {
-	atomic_flag_clear(&mutex->v);
+	atomic_store(&mutex->v, METAL_MUTEX_UNLOCKED);
 }
 
 static inline int __metal_mutex_is_acquired(metal_mutex_t *mutex)

--- a/lib/system/generic/mutex.h
+++ b/lib/system/generic/mutex.h
@@ -26,11 +26,14 @@ typedef struct {
 	atomic_int v;
 } metal_mutex_t;
 
+#define METAL_MUTEX_UNLOCKED 0
+#define METAL_MUTEX_LOCKED   1
+
 /*
- * METAL_MUTEX_INIT - used for initializing an mutex elmenet in a static struct
+ * METAL_MUTEX_INIT - used for initializing an mutex element in a static struct
  * or global
  */
-#define METAL_MUTEX_INIT(m) { ATOMIC_VAR_INIT(0) }
+#define METAL_MUTEX_INIT(m) { ATOMIC_VAR_INIT(METAL_MUTEX_UNLOCKED) }
 /*
  * METAL_MUTEX_DEFINE - used for defining and initializing a global or
  * static singleton mutex
@@ -39,7 +42,7 @@ typedef struct {
 
 static inline void __metal_mutex_init(metal_mutex_t *mutex)
 {
-	atomic_store(&mutex->v, 0);
+	atomic_store(&mutex->v, METAL_MUTEX_UNLOCKED);
 }
 
 static inline void __metal_mutex_deinit(metal_mutex_t *mutex)
@@ -49,19 +52,29 @@ static inline void __metal_mutex_deinit(metal_mutex_t *mutex)
 
 static inline int __metal_mutex_try_acquire(metal_mutex_t *mutex)
 {
-	return 1 - atomic_flag_test_and_set(&mutex->v);
+	int unlocked = METAL_MUTEX_UNLOCKED;
+
+	if (atomic_compare_exchange_strong(&mutex->v, &unlocked,
+					   METAL_MUTEX_LOCKED)) {
+		return 1; /* acquired */
+	} else {
+		return 0; /* not acquired */
+	}
 }
 
 static inline void __metal_mutex_acquire(metal_mutex_t *mutex)
 {
-	while (atomic_flag_test_and_set(&mutex->v)) {
+	int unlocked = METAL_MUTEX_UNLOCKED;
+
+	while (!atomic_compare_exchange_weak(&mutex->v, &unlocked,
+					     METAL_MUTEX_LOCKED)) {
 		;
 	}
 }
 
 static inline void __metal_mutex_release(metal_mutex_t *mutex)
 {
-	atomic_flag_clear(&mutex->v);
+	atomic_store(&mutex->v, METAL_MUTEX_UNLOCKED);
 }
 
 static inline int __metal_mutex_is_acquired(metal_mutex_t *mutex)


### PR DESCRIPTION
The` atomic_flag_*` functions are only defined for operands of the type `atomic_flag` [1] so the previous implementation relied on undefined behavior.
Because of the need for reading the status without side effects (in `__metal_mutex_is_acquired`), it is not possible to use the `atomic_flags` type for the mutex implementation. Because of this, this pull request replaces all  `atomic_flag_*` functions with the appropriate functions for atomic value types.

[1] e.g. see: https://en.cppreference.com/w/c/atomic/atomic_flag_test_and_set