### PR TITLE
Support C++ clients using <atomic>

### DIFF
--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -14,8 +14,87 @@
 
 #include <metal/config.h>
 
-#if defined(HAVE_STDATOMIC_H) && !defined(__STDC_NO_ATOMICS__) && \
-	!defined(__cplusplus)
+#if defined(__cplusplus)
+# include <cstdint>
+
+/*
+ * <atomic> has the same functionality as <stdatomic.h> but all members are only
+ * accessible in the std namespace. As the rest of libmetal is pure C, it does
+ * not know about namespaces, even when compiled as part of a C++ file. So we
+ * just export the members of <atomic> into the global namespace.
+ */
+# include <atomic>
+using std::atomic_flag;
+using std::memory_order;
+
+using std::atomic_bool;
+using std::atomic_char;
+using std::atomic_schar;
+using std::atomic_uchar;
+using std::atomic_short;
+using std::atomic_ushort;
+using std::atomic_int;
+using std::atomic_uint;
+using std::atomic_long;
+using std::atomic_ulong;
+using std::atomic_llong;
+using std::atomic_ullong;
+using std::atomic_char16_t;
+using std::atomic_char32_t;
+using std::atomic_wchar_t;
+using std::atomic_int_least8_t;
+using std::atomic_uint_least8_t;
+using std::atomic_int_least16_t;
+using std::atomic_uint_least16_t;
+using std::atomic_int_least32_t;
+using std::atomic_uint_least32_t;
+using std::atomic_int_least64_t;
+using std::atomic_uint_least64_t;
+using std::atomic_int_fast8_t;
+using std::atomic_uint_fast8_t;
+using std::atomic_int_fast16_t;
+using std::atomic_uint_fast16_t;
+using std::atomic_int_fast32_t;
+using std::atomic_uint_fast32_t;
+using std::atomic_int_fast64_t;
+using std::atomic_uint_fast64_t;
+using std::atomic_intptr_t;
+using std::atomic_uintptr_t;
+using std::atomic_size_t;
+using std::atomic_ptrdiff_t;
+using std::atomic_intmax_t;
+using std::atomic_uintmax_t;
+
+using std::atomic_flag_test_and_set;
+using std::atomic_flag_test_and_set_explicit;
+using std::atomic_flag_clear;
+using std::atomic_flag_clear_explicit;
+using std::atomic_init;
+using std::atomic_is_lock_free;
+using std::atomic_store;
+using std::atomic_store_explicit;
+using std::atomic_load;
+using std::atomic_load_explicit;
+using std::atomic_exchange;
+using std::atomic_exchange_explicit;
+using std::atomic_compare_exchange_strong;
+using std::atomic_compare_exchange_strong_explicit;
+using std::atomic_compare_exchange_weak;
+using std::atomic_compare_exchange_weak_explicit;
+using std::atomic_fetch_add;
+using std::atomic_fetch_add_explicit;
+using std::atomic_fetch_sub;
+using std::atomic_fetch_sub_explicit;
+using std::atomic_fetch_or;
+using std::atomic_fetch_or_explicit;
+using std::atomic_fetch_xor;
+using std::atomic_fetch_xor_explicit;
+using std::atomic_fetch_and;
+using std::atomic_fetch_and_explicit;
+using std::atomic_thread_fence;
+using std::atomic_signal_fence;
+
+#elif defined(HAVE_STDATOMIC_H) && !defined(__STDC_NO_ATOMICS__)
 # include <stdint.h>
 # include <stdatomic.h>
 #elif defined(__GNUC__)

--- a/lib/io.h
+++ b/lib/io.h
@@ -274,16 +274,21 @@ metal_io_write(struct metal_io_region *io, unsigned long offset,
 	if (io->ops.write)
 		(*io->ops.write)(io, offset, value, order, width);
 	else if (ptr && sizeof(atomic_uchar) == width)
-		atomic_store_explicit((atomic_uchar *)ptr, value, order);
+		atomic_store_explicit((atomic_uchar *)ptr, (unsigned char)value,
+				      order);
 	else if (ptr && sizeof(atomic_ushort) == width)
-		atomic_store_explicit((atomic_ushort *)ptr, value, order);
+		atomic_store_explicit((atomic_ushort *)ptr,
+				      (unsigned short)value, order);
 	else if (ptr && sizeof(atomic_uint) == width)
-		atomic_store_explicit((atomic_uint *)ptr, value, order);
+		atomic_store_explicit((atomic_uint *)ptr, (unsigned int)value,
+				      order);
 	else if (ptr && sizeof(atomic_ulong) == width)
-		atomic_store_explicit((atomic_ulong *)ptr, value, order);
+		atomic_store_explicit((atomic_ulong *)ptr, (unsigned long)value,
+				      order);
 #ifndef NO_ATOMIC_64_SUPPORT
 	else if (ptr && sizeof(atomic_ullong) == width)
-		atomic_store_explicit((atomic_ullong *)ptr, value, order);
+		atomic_store_explicit((atomic_ullong *)ptr,
+				      (unsigned long long)value, order);
 #endif
 	else
 		metal_assert(0);


### PR DESCRIPTION
This has been tried (81f85dc244d05448e26aa674301065a1220b4539) and reverted (23c3c332acd7e649033ba63d8905df7d59c1540c) before. This pull request is a bit more elaborate than the first try:

- When the headers are compiled as part of a C++ file, the functions and types from `<atomic>` are exported into the global namespace so that the inline functions still work (ba233adeeb0ed881ddf6c91cba7d35f27d1e5b46)
- A few more explicit typecasts are introduced where needed by the C++ implementation of `atomic_store_explicit` (195d46b46ff0ec825a5b4ce25e45fe1fea085665)
- Because the `atomic_flag_*` C++ functions also perform stricter type checking than the C ones, this depends on #126 