### PR TITLE
Compatibility with pure C11 clients

### DIFF
--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/common.h
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/common.h
@@ -135,7 +135,7 @@ int shmem_throughput_demod();
 
 static inline void wait_for_interrupt()
 {
-	asm volatile("wfi");
+	metal_asm volatile("wfi");
 }
 
 /**

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/common.h
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/common.h
@@ -136,7 +136,7 @@ int shmem_throughput_demod();
 
 static inline void wait_for_interrupt()
 {
-	asm volatile("wfi");
+	metal_asm volatile("wfi");
 }
 
 /**

--- a/lib/compiler/gcc/compiler.h
+++ b/lib/compiler/gcc/compiler.h
@@ -20,6 +20,17 @@ extern "C" {
 #define metal_align(n) __attribute__((aligned(n)))
 #define metal_weak __attribute__((weak))
 
+#if defined(__STRICT_ANSI__)
+#define metal_asm __asm__
+#else
+/*
+ * Even though __asm__ is always available in mainline GCC, we use asm in
+ * the non-strict modes for compatibility with other compilers that define
+ * __GNUC__
+ */
+#define metal_asm asm
+#endif
+
 #define METAL_PACKED_BEGIN
 #define METAL_PACKED_END __attribute__((__packed__))
 

--- a/lib/compiler/iar/compiler.h
+++ b/lib/compiler/iar/compiler.h
@@ -19,6 +19,7 @@ extern "C" {
 #define restrict __restrict__
 #define metal_align(n) __attribute__((aligned(n)))
 #define metal_weak __attribute__((weak))
+#define metal_asm asm
 
 #define METAL_PACKED_BEGIN __packed
 #define METAL_PACKED_END

--- a/lib/processor/aarch64/cpu.h
+++ b/lib/processor/aarch64/cpu.h
@@ -12,6 +12,11 @@
 #ifndef __METAL_AARCH64_CPU__H__
 #define __METAL_AARCH64_CPU__H__
 
-#define metal_cpu_yield() asm volatile("yield")
+#include <metal/compiler.h>
+
+static inline void metal_cpu_yield(void)
+{
+	metal_asm volatile("yield");
+}
 
 #endif /* __METAL_AARCH64_CPU__H__ */

--- a/lib/processor/x86/cpu.h
+++ b/lib/processor/x86/cpu.h
@@ -12,6 +12,11 @@
 #ifndef __METAL_X86_CPU__H__
 #define __METAL_X86_CPU__H__
 
-#define metal_cpu_yield() asm volatile("rep; nop")
+#include <metal/compiler.h>
+
+static inline void metal_cpu_yield(void)
+{
+	metal_asm volatile("rep; nop");
+}
 
 #endif /* __METAL_X86_CPU__H__ */

--- a/lib/processor/x86_64/cpu.h
+++ b/lib/processor/x86_64/cpu.h
@@ -12,6 +12,11 @@
 #ifndef __METAL_X86_64_CPU__H__
 #define __METAL_X86_64_CPU__H__
 
-#define metal_cpu_yield() asm volatile("rep; nop")
+#include <metal/compiler.h>
+
+static inline void metal_cpu_yield(void)
+{
+	metal_asm volatile("rep; nop");
+}
 
 #endif /* __METAL_X86_64_CPU__H__ */

--- a/lib/system/freertos/zynq7/sys.c
+++ b/lib/system/freertos/zynq7/sys.c
@@ -64,7 +64,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
  */
 void metal_weak metal_generic_default_poll(void)
 {
-	asm volatile("wfi");
+	metal_asm volatile("wfi");
 }
 
 void *metal_machine_io_mem_map(void *va, metal_phys_addr_t pa,

--- a/lib/system/freertos/zynqmp_a53/sys.c
+++ b/lib/system/freertos/zynqmp_a53/sys.c
@@ -58,7 +58,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
  */
 void metal_weak metal_generic_default_poll(void)
 {
-	asm volatile("wfi");
+	metal_asm volatile("wfi");
 }
 
 void *metal_machine_io_mem_map(void *va, metal_phys_addr_t pa,

--- a/lib/system/freertos/zynqmp_r5/sys.c
+++ b/lib/system/freertos/zynqmp_r5/sys.c
@@ -58,7 +58,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
  */
 void metal_weak metal_generic_default_poll(void)
 {
-	asm volatile("wfi");
+	metal_asm volatile("wfi");
 }
 
 void *metal_machine_io_mem_map(void *va, metal_phys_addr_t pa,

--- a/lib/system/generic/microblaze_generic/sys.c
+++ b/lib/system/generic/microblaze_generic/sys.c
@@ -27,8 +27,8 @@ unsigned int sys_irq_save_disable(void)
 {
 	unsigned int state;
 
-	asm volatile("  mfs     %0, rmsr	\n"
-		     "  msrclr  r0, %1		\n"
+	metal_asm volatile("  mfs     %0, rmsr\n"
+		     "  msrclr  r0, %1\n"
 		     :  "=r"(state)
 		     :  "i"(MSR_IE)
 		     :  "memory");
@@ -41,9 +41,9 @@ void sys_irq_restore_enable(unsigned int flags)
 	unsigned int tmp;
 
 	if (flags)
-		asm volatile("  msrset %0, %1	\n"
-			 :  "=r"(tmp)
-			 :  "i"(MSR_IE)
+		metal_asm volatile("  msrset %0, %1\n"
+			 : "=r"(tmp)
+			 : "i"(MSR_IE)
 			 :  "memory");
 }
 
@@ -52,9 +52,9 @@ unsigned int sys_irq_save_disable(void)
 {
 	unsigned int tmp, state;
 
-	asm volatile ("  mfs   %0, rmsr		\n"
-		      "  andi  %1, %0, %2	\n"
-		      "  mts   rmsr, %1		\n"
+	metal_asm volatile ("  mfs   %0, rmsr\n"
+		      "  andi  %1, %0, %2\n"
+		      "  mts   rmsr, %1\n"
 		      :  "=r"(state), "=r"(tmp)
 		      :  "i"(~MSR_IE)
 		      :  "memory");
@@ -67,9 +67,9 @@ void sys_irq_restore_enable(unsigned int flags)
 	unsigned int tmp;
 
 	if (flags)
-		asm volatile("  mfs    %0, rmsr		\n"
-			 "  or      %0, %0, %1	\n"
-			 "  mts     rmsr, %0	\n"
+		metal_asm volatile("  mfs    %0, rmsr\n"
+			 "  or      %0, %0, %1\n"
+			 "  mts     rmsr, %0\n"
 			 :  "=r"(tmp)
 			 :  "r"(flags)
 			 :  "memory");
@@ -135,7 +135,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
  */
 void metal_weak metal_generic_default_poll(void)
 {
-	asm volatile("nop");
+	metal_asm volatile("nop");
 }
 
 void *metal_machine_io_mem_map(void *va, metal_phys_addr_t pa,

--- a/lib/system/generic/zynq7/sys.c
+++ b/lib/system/generic/zynq7/sys.c
@@ -61,7 +61,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
  */
 void metal_weak metal_generic_default_poll(void)
 {
-	asm volatile("wfi");
+	metal_asm volatile("wfi");
 }
 
 void *metal_machine_io_mem_map(void *va, metal_phys_addr_t pa,

--- a/lib/system/generic/zynqmp_a53/sys.c
+++ b/lib/system/generic/zynqmp_a53/sys.c
@@ -58,7 +58,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
  */
 void metal_weak metal_generic_default_poll(void)
 {
-	asm volatile("wfi");
+	metal_asm volatile("wfi");
 }
 
 void *metal_machine_io_mem_map(void *va, metal_phys_addr_t pa,

--- a/lib/system/generic/zynqmp_r5/sys.c
+++ b/lib/system/generic/zynqmp_r5/sys.c
@@ -58,7 +58,7 @@ void metal_machine_cache_invalidate(void *addr, unsigned int len)
  */
 void metal_weak metal_generic_default_poll(void)
 {
-	asm volatile("wfi");
+	metal_asm volatile("wfi");
 }
 
 void *metal_machine_io_mem_map(void *va, metal_phys_addr_t pa,

--- a/lib/system/zephyr/cortexm/sys.c
+++ b/lib/system/zephyr/cortexm/sys.c
@@ -18,5 +18,5 @@
  */
 void metal_weak metal_generic_default_poll(void)
 {
-	__asm__ __volatile__("wfi");
+	metal_asm __volatile__("wfi");
 }

--- a/test/system/freertos/main.c
+++ b/test/system/freertos/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <metal/compiler.h>
 #include "metal-test.h"
 #include "FreeRTOS.h"
 #include "task.h"
@@ -33,7 +34,7 @@ int main(void)
 
 	/* Will not get here, unless a call is made to vTaskEndScheduler() */
 	while (1) {
-		__asm__("wfi\n\t");
+		metal_asm("wfi\n\t");
 	}
 
 	/* suppress compilation warnings*/


### PR DESCRIPTION
This patch makes a test file which includes all metal headers compile with the following arguments: -std=c11 -pedantic.

It is the reworked form of the draft pull request #125 

Tested with GCC 8.2.0.