### PR TITLE
FreeRTOS: fix sleep and timestamp handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,3 +287,5 @@ We use standard github mechanism for pull request. Please refer to github docume
 
 ## Communication and Collaboration
 [Subscribe](https://lists.openampproject.org/mailman/listinfo/openamp-rp) to the OpenAMP mailing list(openamp-rp@lists.openampproject.org).
+
+For more details on the framework please refer to the the [OpenAMP wiki](https://github.com/OpenAMP/open-amp/wiki).

--- a/lib/system/freertos/sleep.h
+++ b/lib/system/freertos/sleep.h
@@ -25,9 +25,9 @@ extern "C" {
 
 static inline int __metal_sleep_usec(unsigned int usec)
 {
-	const TickType_t xDelay = usec / portTICK_PERIOD_MS;
+	const TickType_t xDelay = ((usec/1000) / portTICK_PERIOD_MS);
 
-	vTaskDelay(xDelay);
+	vTaskDelay(xDelay ? xDelay : 1);
 	return 0;
 }
 

--- a/lib/system/freertos/time.c
+++ b/lib/system/freertos/time.c
@@ -15,6 +15,6 @@
 
 unsigned long long metal_get_timestamp(void)
 {
-	return (unsigned long long)xTaskGetTickCount();
+	return (unsigned long long)(1000 * portTICK_PERIOD_MS * xTaskGetTickCount());
 }
 

--- a/test/system/freertos/sleep.c
+++ b/test/system/freertos/sleep.c
@@ -18,14 +18,17 @@
 static int sleep(void)
 {
 	int rc;
-	unsigned int usec = 3;
-	unsigned long long tstart, tend, tdelayed;
+	unsigned int usec = 150000;
+	unsigned long long tstart, tend, tdelayed, tolerance;
+
 
 	tstart = metal_get_timestamp();
-	metal_sleep_usec((usec/portTICK_PERIOD_MS));
+	metal_sleep_usec(usec);
 	tend = metal_get_timestamp();
 	tdelayed = tend - tstart;
-	if (tdelayed > (usec/portTICK_PERIOD_MS))
+	/* allow +/- 1 OS tick */
+	tolerance = portTICK_PERIOD_MS * 1000;
+	if (tdelayed > (usec + tolerance) || tdelayed < (usec - tolerance))
 		rc = -1;
 	else
 		rc = 0;


### PR DESCRIPTION
libmetal's libmetal_sleep_usec() takes a sleep time in micro-seconds.
The FreeRTOS function underlying it takes a sleep time in task ticks.
This was not properly corrected for, resulting in sleep times that
were off by an order of magnitude. The test code attempted to
correct for this as well, in the same wrong way.

Lastly, the metal_get_timestamp() function returned a value in
task ticks alone. This is a configuration dependent value.

This patch changes all three places to use microseconds for the
input and output values.

Addresses https://github.com/OpenAMP/libmetal/issues/117#