### PR TITLE
compiler: introduce __deprecated attribute

### DIFF
--- a/lib/compiler/gcc/compiler.h
+++ b/lib/compiler/gcc/compiler.h
@@ -34,6 +34,10 @@ extern "C" {
 #define METAL_PACKED_BEGIN
 #define METAL_PACKED_END __attribute__((__packed__))
 
+#ifndef __deprecated
+#define __deprecated	__attribute__((deprecated))
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/compiler/iar/compiler.h
+++ b/lib/compiler/iar/compiler.h
@@ -24,6 +24,10 @@ extern "C" {
 #define METAL_PACKED_BEGIN __packed
 #define METAL_PACKED_END
 
+#ifndef __deprecated
+#define __deprecated	__attribute__((deprecated))
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR is related to the issue https://github.com/OpenAMP/open-amp/issues/220


Define the __deprecated attribute to allow to generate a warning message
on compilation when an API is declared as deprecated.
This warning can be cleaned by adding -Wno-deprecated-declarations in
CMAKE_C_FLAGS flags