### PR TITLE
CI: fix compliance check false report when merge a PR.

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -4,12 +4,6 @@
 name: libmetal compliance checks
 
 on:
-  push:
-    branches: [ master ]
-    paths-ignore:
-      - docs/**
-      - cmake/**
-      - scripts/**
   pull_request:
     branches: [ master ]
     paths-ignore:


### PR DESCRIPTION
When a PR is merged, a "Run failed: libmetal compliance checks - master"
mail is generated.
As it is not necessary to rerun this compliance check (already done
on sent PR), just suppress the action for push event.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>