### PR TITLE
lib/system/linux: fix memory leak in metal_uio_read_map_attr()

### DIFF
--- a/lib/system/linux/device.c
+++ b/lib/system/linux/device.c
@@ -87,10 +87,14 @@ static int metal_uio_read_map_attr(struct linux_device *ldev,
 	if (result >= (int)sizeof(path))
 		return -EOVERFLOW;
 	attr = sysfs_open_attribute(path);
-	if (!attr || sysfs_read_attribute(attr) != 0)
+	if (!attr || sysfs_read_attribute(attr) != 0) {
+		sysfs_close_attribute(attr);
 		return -errno;
+	}
 
 	*value = strtoul(attr->value, NULL, 0);
+
+	sysfs_close_attribute(attr);
 	return 0;
 }
 


### PR DESCRIPTION
Hello,

It seems like metal_uio_read_map_attr() function is leaking a resource, please see valgrind output produced using a simple demo program that only open and close a device:

```
==2121== Memcheck, a memory error detector                                                                                                                                                                           
==2121== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.                                                                                                                                             
==2121== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info                                                                                                                                          
==2121== Command: /usr/bin/test-libmetal                                                                                                                                                                             
==2121==                                                                                                                                                                                                             
metal: info:      metal_uio_dev_open: No IRQ for device a0090000.dev.                                                                                                                                                                                                                                                                                                                                          
==2121==                                                                                                                                                                                                             
==2121== HEAP SUMMARY:                                                                                                                                                                                               
==2121==     in use at exit: 1,053 bytes in 6 blocks                                                                                                                                                                 
==2121==   total heap usage: 26 allocs, 20 frees, 154,936 bytes allocated                                                                                                                                            
==2121==                                                                                                                                                                                                             
==2121== 341 (336 direct, 5 indirect) bytes in 1 blocks are definitely lost in loss record 4 of 6                                                                                                                    
==2121==    at 0x484A614: calloc (vg_replace_malloc.c:752)                                                                                                                                                           
==2121==    by 0x4BA0147: sysfs_open_attribute (in /lib/libsysfs.so.2.0.1)                                                                                                                                           
==2121==    by 0x48696E7: metal_uio_read_map_attr (device.c:89)                                                                                                                                                      
==2121==    by 0x4869A33: metal_uio_dev_open (device.c:231)                                                                                                                                                          
==2121==    by 0x48695AF: metal_linux_dev_open (device.c:446)                                                                                                                                                        
==2121==    by 0x48684D3: metal_device_open (device.c:72)                                                                                                                                                            
==2121==    by 0x108BCB: main (main.cpp:19)                                                                                                                                                                          
==2121==                                                                                                                                                                                                             
==2121== 356 (336 direct, 20 indirect) bytes in 1 blocks are definitely lost in loss record 5 of 6                                                                                                                   
==2121==    at 0x484A614: calloc (vg_replace_malloc.c:752)                                                                                                                                                           
==2121==    by 0x4BA0147: sysfs_open_attribute (in /lib/libsysfs.so.2.0.1)                                                                                                                                           
==2121==    by 0x48696E7: metal_uio_read_map_attr (device.c:89)                                                                                                                                                      
==2121==    by 0x4869AC7: metal_uio_dev_open (device.c:233)                                                                                                                                                          
==2121==    by 0x48695AF: metal_linux_dev_open (device.c:446)                                                                                                                                                        
==2121==    by 0x48684D3: metal_device_open (device.c:72)                                                                                                                                                            
==2121==    by 0x108BCB: main (main.cpp:19)                                                                                                                                                                          
==2121==                                                                                                                                                                                                             
==2121== 356 (336 direct, 20 indirect) bytes in 1 blocks are definitely lost in loss record 6 of 6                                                                                                                   
==2121==    at 0x484A614: calloc (vg_replace_malloc.c:752)                                                                                                                                                           
==2121==    by 0x4BA0147: sysfs_open_attribute (in /lib/libsysfs.so.2.0.1)                                                                                                                                           
==2121==    by 0x48696E7: metal_uio_read_map_attr (device.c:89)                                                                                                                                                      
==2121==    by 0x4869ADB: metal_uio_dev_open (device.c:235)                                                                                                                                                          
==2121==    by 0x48695AF: metal_linux_dev_open (device.c:446)                                                                                                                                                        
==2121==    by 0x48684D3: metal_device_open (device.c:72)                                                                                                                                                            
==2121==    by 0x108BCB: main (main.cpp:19)                                                                                                                                                                          
==2121==                                                                                                                                                                                                             
==2121== LEAK SUMMARY:                                                                                                                                                                                               
==2121==    definitely lost: 1,008 bytes in 3 blocks                                                                                                                                                                 
==2121==    indirectly lost: 45 bytes in 3 blocks                                                                                                                                                                    
==2121==      possibly lost: 0 bytes in 0 blocks                                                                                                                                                                     
==2121==    still reachable: 0 bytes in 0 blocks                                                                                                                                                                     
==2121==         suppressed: 0 bytes in 0 blocks                                                                                                                                                                     
==2121==                                                                                                                                                                                                             
==2121== For counts of detected and suppressed errors, rerun with: -v                                                                                                                                                
==2121== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)
```

```
#include <iostream>                                                                                                                                                                                                  
#include <metal/sys.h>                                                                                                                                                                                               
#include <metal/device.h>                                                                                                                                                                                            
                                                                                                                                                                                                                     
int main()                                                                                                                                                                                      
{                                                                                                                                                                                                                                                                                                                                                                                                                 
    int ret;                                                                                                                                                                                                         
    struct metal_init_params init_param = METAL_INIT_DEFAULTS;                                                                                                                                                       
    ret = metal_init(&init_param);                                                                                                                                                                                   
    if (ret) {                                                                                                                                                                                                       
        std::cerr << "Failed to initialize libmetal" << std::endl;                                                                                                                                                   
        return ret;                                                                                                                                                                                                  
    }                                                                                                                                                                                                                
                                                                                                                                                                                                                     
    struct metal_device *dev;                                                                                                                                                                                        
    ret = metal_device_open("platform", "a0090000.dev", &dev);                                                                                                                                                      
    if (ret) {                                                                                                                                                                                                       
        std::cerr << "Failed to open a0090000.dev" << std::endl;                                                                                                                                                    
        metal_finish();                                                                                                                                                                                              
        return ret;                                                                                                                                                                                                  
    }                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                        
    metal_device_close(dev);
                                                                                                                                            
    metal_finish();                                                                                                                                                                                                  
                                                                                                                                                                                                                     
    return ret;                                                                                                                                                                                                      
}
```

After applying the patch, the memory leak is gone:
```==2155== Memcheck, a memory error detector                                                                                                                                                                           
==2155== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.                                                                                                                                             
==2155== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info                                                                                                                                          
==2155== Command: /usr/bin/test-libmetal                                                                                                                                                                             
==2155==                                                                                                                                                                                                             
metal: info:      metal_uio_dev_open: No IRQ for device a0090000.dev.                                                                                                                                                                                                                                                                                                                                              
==2155==                                                                                                                                                                                                             
==2155== HEAP SUMMARY:                                                                                                                                                                                               
==2155==     in use at exit: 0 bytes in 0 blocks                                                                                                                                                                     
==2155==   total heap usage: 26 allocs, 26 frees, 154,936 bytes allocated                                                                                                                                            
==2155==                                                                                                                                                                                                             
==2155== All heap blocks were freed -- no leaks are possible                                                                                                                                                         
==2155==                                                                                                                                                                                                             
==2155== For counts of detected and suppressed errors, rerun with: -v                                                                                                                                                
==2155== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Signed-off-by: Leo Sartre <sartre.l@ecagroup.com>