### PR TITLE
Linux: fix misunderstanding of the offset devicetree node in the map

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ implementation for metal_sys_init and metal_sys_finish.
 For Linux userspace, metal_sys_init sets up a table for available shared pages,
 checks whether UIO/VFIO drivers are avail, and starts interrupt handling
 thread.
+Please note that on Linux, to access device's memory that is not page
+aligned, an offset has to be added to the pointer returned by
+mmap(). This `offset`, although it can be read from the device tree
+property exposed by the uio driver, is not handled yet by the
+library.
 
 For bare-metal, metal_sys_init and metal_sys_finish just returns.
 

--- a/lib/system/linux/device.c
+++ b/lib/system/linux/device.c
@@ -234,7 +234,7 @@ static int metal_uio_dev_open(struct linux_bus *lbus, struct linux_device *ldev)
 		result = (result ? result :
 			 metal_uio_read_map_attr(ldev, i, "size", &size));
 		result = (result ? result :
-			 metal_map(ldev->fd, offset, size, 0, 0, &virt));
+			 metal_map(ldev->fd, i * getpagesize(), size, 0, 0, &virt));
 		if (!result) {
 			io = &ldev->device.regions[ldev->device.num_regions];
 			metal_io_init(io, virt, phys, size, -1, 0, NULL);


### PR DESCRIPTION
I think there is a confusion about the of node "offset" of the uio map regions.
According to the user io documentation (https://www.kernel.org/doc/html/latest/driver-api/uio-howto.html), the offset node is 

> The offset, in bytes, that has to be added to the pointer returned by mmap()

this is NOT the offset to be passed to mmap.

The offset to give to mmap to get the Nth region is N times the pagesize as explained in the same documentation:

> From userspace, the different mappings are distinguished by adjusting the offset parameter of the mmap() call. To map the memory of mapping N, you have to use N times the page size as your offset:

```
offset = N * getpagesize();
```

The first patch https://github.com/OpenAMP/libmetal/pull/137/commits/2219961d1dc73d2f3e484f2701cf8fa18ebde1c7 of this series correct this issue.  

For the second https://github.com/OpenAMP/libmetal/pull/137/commits/357afeb7ae75d88dc3ae1aa8f6c06cd1803f48cc , that is tagged as [DO NOT MERGE], I'm not sure that adding a new field in the common structure `metal_io_region` that will be used only for linux is legit. Maybe we rather need to handle this in the `metal_io_ops`. I'm not familiar enough with libmetal, maybe someone with more insight can give a thought...
I do not have a lot of time now, and since I do not have the "Non page aligned" use case I cannot test easily, but I may find some time to produce a test bench for this scenario in the future.
What do you think?