### PR TITLE
Abailon/i500 upstream v1

### DIFF
--- a/cmake/platforms/i500-apu-generic.cmake
+++ b/cmake/platforms/i500-apu-generic.cmake
@@ -1,0 +1,13 @@
+set (CMAKE_SYSTEM_PROCESSOR "xtensa"              CACHE STRING "")
+set (MACHINE                "i500_apu"            CACHE STRING "")
+set (CROSS_PREFIX           "xtensa-unknown-elf-" CACHE STRING "")
+
+option (CORE_ID "Build libmetal for a specific core" )
+if (NOT DEFINED CORE_ID)
+  set (CORE_ID "0")
+endif (NOT DEFINED CORE_ID)
+message ("-- Building libmetal for i500 APU core ${CORE_ID}")
+
+set (CMAKE_C_FLAGS          "-DI500_CORE_ID=${CORE_ID}" CACHE STRING "")
+
+include (cross-generic-gcc)

--- a/lib/io.h
+++ b/lib/io.h
@@ -30,7 +30,7 @@ extern "C" {
  *  @{
  */
 
-#ifdef __MICROBLAZE__
+#if defined (__MICROBLAZE__) || defined (__XTENSA__)
 #define NO_ATOMIC_64_SUPPORT
 #endif
 

--- a/lib/processor/xtensa/CMakeLists.txt
+++ b/lib/processor/xtensa/CMakeLists.txt
@@ -1,0 +1,2 @@
+collect (PROJECT_LIB_HEADERS atomic.h)
+collect (PROJECT_LIB_HEADERS cpu.h)

--- a/lib/processor/xtensa/atomic.h
+++ b/lib/processor/xtensa/atomic.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2020, BayLibre
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	gcc/atomic.h
+ * @brief	GCC specific atomic primitives for libmetal.
+ */
+
+#ifndef __METAL_XTENSA_ATOMIC__H__
+#define __METAL_XTENSA_ATOMIC__H__
+
+#endif /* __METAL_XTENSA_ATOMIC__H__ */

--- a/lib/processor/xtensa/cpu.h
+++ b/lib/processor/xtensa/cpu.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2020, BayLibre
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	cpu.h
+ * @brief	CPU specific primatives
+ */
+
+#ifndef __METAL_XTENSA_CPU__H__
+#define __METAL_XTENSA_CPU__H__
+
+#define metal_cpu_yield()
+
+/*
+ * The dummy implementation is enough here since xtensa dsp don't
+ * support the out of order and multi core support is not implemented.
+ */
+static inline void __sync_synchronize(void) {}
+
+#endif /* __METAL_XTENSA_CPU__H__ */

--- a/lib/system/generic/i500_apu/CMakeLists.txt
+++ b/lib/system/generic/i500_apu/CMakeLists.txt
@@ -1,0 +1,6 @@
+collect (PROJECT_LIB_HEADERS sys.h)
+
+collect (PROJECT_LIB_SOURCES irq.c)
+collect (PROJECT_LIB_SOURCES sys.c)
+
+add_subdirectory(../xtensa_common ${CMAKE_CURRENT_BINARY_DIR}/../xtensa_common)

--- a/lib/system/generic/i500_apu/irq.c
+++ b/lib/system/generic/i500_apu/irq.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020, BayLibre
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	generic/i500_apu/sys.c
+ * @brief	machine specific system primitives implementation.
+ */
+
+#include <metal/irq.h>
+#include <metal/irq_controller.h>
+#include <metal/sys.h>
+#include <metal/utilities.h>
+
+#include <xtensa/xtruntime.h>
+
+#define MAX_IRQS 25
+#define VPU_INT_TO_XTENSA_CLR_REG	0x0000011C
+#define VPU_INT_MASK_REG		0x0000012C
+
+static struct metal_irq irqs[MAX_IRQS];
+
+static void i500_irq_enable(int32_t number)
+{
+	uint32_t value;
+
+	sys_irq_enable(number);
+	value = i500_read_reg(VPU_INT_MASK_REG);
+	value &= ~(1 << number);
+	i500_write_reg(VPU_INT_MASK_REG, value);
+}
+
+static void i500_irq_disable(uint32_t number)
+{
+	uint32_t value;
+
+	value = i500_read_reg(VPU_INT_MASK_REG);
+	value |= (1 << number);
+	i500_write_reg(VPU_INT_MASK_REG, value);
+	sys_irq_disable(number);
+}
+
+static void i500_irq_clear(uint32_t number)
+{
+	i500_write_reg(VPU_INT_TO_XTENSA_CLR_REG, 1 << number);
+}
+
+static void i500_irq_handler(void *arg)
+{
+	uint32_t number = (uint32_t)arg;
+
+	if (irqs[number].hd)
+		irqs[number].hd((int)number, irqs[number].arg);
+	i500_irq_clear(number);
+}
+
+static void i500_irq_set_enable(struct metal_irq_controller *cntr,
+				  int irq, unsigned int state)
+{
+	if (irq < cntr->irq_base ||
+	    irq >= cntr->irq_base + cntr->irq_num) {
+		metal_log(METAL_LOG_ERROR, "%s: invalid irq %d\n",
+			  __func__, irq);
+		return;
+	} else if (state == METAL_IRQ_ENABLE) {
+		i500_irq_enable(irq);
+		sys_irq_enable((unsigned int)irq);
+	} else {
+		sys_irq_disable((unsigned int)irq);
+		i500_irq_disable(irq);
+	}
+}
+
+static int i500_irq_register(struct metal_irq_controller *cntr,
+			       int irq, metal_irq_handler hd, void *arg)
+{
+	metal_unused(arg);
+	xtos_handler old;
+
+	if (irq < cntr->irq_base ||
+	    irq >= cntr->irq_base + cntr->irq_num)
+		return -EINVAL;
+
+	if (!hd) {
+		xtos_set_interrupt_handler(irq, NULL, NULL, &old);
+	} else {
+		irqs[irq].hd = hd;
+		irqs[irq].arg = arg;
+		xtos_set_interrupt_handler(irq, i500_irq_handler,
+					   (void *)irq, &old);
+	}
+
+	return 0;
+}
+
+
+static METAL_IRQ_CONTROLLER_DECLARE(i500_irq_controller, 0, MAX_IRQS, NULL,
+				    i500_irq_set_enable, i500_irq_register,
+				    irqs);
+
+int i500_irq_init(void)
+{
+	i500_write_reg(VPU_INT_MASK_REG, 0xFFFF);
+
+	return metal_irq_register_controller(&i500_irq_controller);
+}

--- a/lib/system/generic/i500_apu/sys.c
+++ b/lib/system/generic/i500_apu/sys.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, BayLibre
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	generic/i500_apu/sys.c
+ * @brief	machine specific system primitives implementation.
+ */
+
+#include <metal/compiler.h>
+#include <metal/io.h>
+#include <metal/sys.h>
+#include <metal/utilities.h>
+#include <stdint.h>
+
+#include <xtensa/hal.h>
+#include <xtensa/tie/ipu_if2.h>
+
+#if !defined(I500_CORE_ID)
+#error "Undefined core id"
+#endif
+
+#if I500_CORE_ID == 0
+#define BASE_ADDRESS 0x19180000
+#elif I500_CORE_ID == 1
+#define BASE_ADDRESS 0x19280000
+#else
+#error "Unknown core id"
+#endif
+
+void i500_write_reg(uint32_t addr, uint32_t value)
+{
+	unsigned int level;
+
+	level = sys_irq_save_disable();
+	IPU_SendAPBWrite(value, BASE_ADDRESS + addr);
+	sys_irq_restore_enable(level);
+}
+
+uint32_t i500_read_reg(uint32_t addr)
+{
+	uint32_t value = 0;
+
+	IPU_SendAPBRead(value, BASE_ADDRESS + addr);
+	value = IPU_ReadAPB();
+
+	return value;
+}

--- a/lib/system/generic/i500_apu/sys.h
+++ b/lib/system/generic/i500_apu/sys.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020, BayLibre
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	generic/i500_apu/sys.h
+ * @brief	generic i500_apu system primitives for libmetal.
+ */
+
+#ifndef __METAL_GENERIC_SYS__H__
+#error "Include metal/sys.h instead of metal/system/generic/@PROJECT_MACHINE@/sys.h"
+#endif
+
+#include <metal/system/@PROJECT_SYSTEM@/xtensa_common/sys.h>
+
+#ifndef __METAL_I500_APU_SYS__H__
+#define __METAL_I500_APU_SYS__H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void i500_write_reg(uint32_t addr, uint32_t value);
+uint32_t i500_read_reg(uint32_t addr);
+
+int i500_irq_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_I500_APU_SYS__H__ */

--- a/lib/system/generic/xtensa_common/CMakeLists.txt
+++ b/lib/system/generic/xtensa_common/CMakeLists.txt
@@ -1,0 +1,4 @@
+collect (PROJECT_LIB_HEADERS sys.h)
+
+collect (PROJECT_LIB_SOURCES atomic.c)
+collect (PROJECT_LIB_SOURCES sys.c)

--- a/lib/system/generic/xtensa_common/atomic.c
+++ b/lib/system/generic/xtensa_common/atomic.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, BayLibre
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	generic/i500_apu/atomic.c
+ * @brief	machine specific atomic primitives implementation.
+ */
+
+#include <metal/atomic.h>
+#include <metal/irq.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+
+unsigned int __atomic_fetch_add_4(volatile void *ptr, unsigned int val,
+				  int memorder)
+{
+	unsigned int tmp;
+	unsigned int flags;
+	(void)memorder;
+
+	flags = metal_irq_save_disable();
+	tmp = *((unsigned int *)ptr);
+	*((unsigned int *)ptr) = tmp + val;
+	metal_irq_restore_enable(flags);
+
+	return tmp;
+}
+
+bool __atomic_compare_exchange_4(volatile void *ptr, void *expected,
+				 unsigned int desired, bool weak,
+				 int success_memorder, int failure_memorder)
+{
+	bool ret;
+	unsigned int flags;
+
+	flags = metal_irq_save_disable();
+
+	(void)success_memorder;
+	(void)failure_memorder;
+	(void)weak;
+	if (*((unsigned int *)ptr) == *((unsigned int *)expected)) {
+		*((unsigned int *)ptr) = desired;
+		ret = true;
+	} else {
+		*((unsigned int *)expected) = *((unsigned int *)ptr);
+		ret = false;
+	}
+	metal_irq_restore_enable(flags);
+
+	return ret;
+}

--- a/lib/system/generic/xtensa_common/sys.c
+++ b/lib/system/generic/xtensa_common/sys.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, BayLibre
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	generic/xtensa_common/sys.c
+ * @brief	machine specific system primitives implementation.
+ */
+
+#include <metal/compiler.h>
+#include <metal/io.h>
+#include <metal/sys.h>
+#include <metal/utilities.h>
+
+#include <xtensa/hal.h>
+
+void metal_machine_cache_flush(void *addr, unsigned int len)
+{
+	xthal_dcache_block_writeback(addr, len);
+}
+
+void metal_machine_cache_invalidate(void *addr, unsigned int len)
+{
+	xthal_dcache_block_invalidate(addr, len);
+}
+
+void metal_generic_default_poll(void)
+{
+	XT_WAITI(0);
+}
+
+void *metal_machine_io_mem_map(void *va, metal_phys_addr_t pa,
+			       size_t size, unsigned int flags)
+{
+	metal_unused(pa);
+	metal_unused(size);
+	metal_unused(flags);
+
+	return va;
+}

--- a/lib/system/generic/xtensa_common/sys.h
+++ b/lib/system/generic/xtensa_common/sys.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, BayLibre
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	generic/xtensa_common/sys.h
+ * @brief	generic xtensa_common system primitives for libmetal.
+ */
+
+#ifndef __METAL_GENERIC_SYS__H__
+#error "Include metal/sys.h instead of metal/system/generic/xtensa_common/sys.h"
+#endif
+
+#include <xtensa/xtruntime.h>
+#include <xtensa/config/core-isa.h>
+
+#ifndef __METAL_XTENSA_SYS__H__
+#define __METAL_XTENSA_SYS__H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef METAL_INTERNAL
+
+static inline void sys_irq_enable(unsigned int vector)
+{
+	_xtos_interrupt_enable(vector);
+}
+
+static inline void sys_irq_disable(unsigned int vector)
+{
+	_xtos_interrupt_disable(vector);
+}
+
+static inline void sys_irq_restore_enable(unsigned int flags)
+{
+	XTOS_RESTORE_INTLEVEL(flags);
+}
+
+static inline unsigned int sys_irq_save_disable(void)
+{
+	return XTOS_DISABLE_EXCM_INTERRUPTS;
+}
+
+#endif /* METAL_INTERNAL */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_XTENSA_SYS__H__ */

--- a/test/system/generic/i500_apu/CMakeLists.txt
+++ b/test/system/generic/i500_apu/CMakeLists.txt
@@ -1,0 +1,9 @@
+collect (PROJECT_LIB_TESTS helper.c)
+collect (PROJECT_LIB_TESTS rsc_table.c)
+
+set (_linker_script "${CMAKE_CURRENT_SOURCE_DIR}/ldscripts/elf32xtensa.x")
+
+set_property (GLOBAL PROPERTY TEST_LINKER_OPTIONS "-Wl,-build-id=none -specs=${CMAKE_CURRENT_SOURCE_DIR}/specs -T\"${_linker_script}\"")
+
+collect(PROJECT_LIB_DEPS c)
+collect(PROJECT_LIB_DEPS m)

--- a/test/system/generic/i500_apu/helper.c
+++ b/test/system/generic/i500_apu/helper.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2020, BayLibre
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <metal/irq.h>
+#include <metal/sys.h>
+
+#include "rsc_table.h"
+
+int init_system(void)
+{
+	return i500_irq_init();
+}
+
+void cleanup_system(void)
+{
+}

--- a/test/system/generic/i500_apu/ldscripts/elf32xtensa.x
+++ b/test/system/generic/i500_apu/ldscripts/elf32xtensa.x
@@ -1,0 +1,510 @@
+/* This linker script generated from xt-genldscripts.tpp for LSP . */
+/* Linker Script for default link */
+MEMORY
+{
+  srom0_seg :                         	org = 0x50000000, len = 0x300
+  srom1_seg :                         	org = 0x50000300, len = 0xFFD00
+  sram0_seg :                         	org = 0x60000000, len = 0x180
+  sram1_seg :                         	org = 0x60000180, len = 0x40
+  sram2_seg :                         	org = 0x600001C0, len = 0x40
+  sram3_seg :                         	org = 0x60000200, len = 0x40
+  sram4_seg :                         	org = 0x60000240, len = 0x40
+  sram5_seg :                         	org = 0x60000280, len = 0x80
+  sram6_seg :                         	org = 0x60000300, len = 0x40
+  sram7_seg :                         	org = 0x60000340, len = 0xFFCC0
+  log_seg :                         	org = 0x60100000, len = 0x200000
+}
+
+PHDRS
+{
+  srom0_phdr PT_LOAD;
+  srom1_phdr PT_LOAD;
+  sram0_phdr PT_LOAD;
+  sram1_phdr PT_LOAD;
+  sram2_phdr PT_LOAD;
+  sram3_phdr PT_LOAD;
+  sram4_phdr PT_LOAD;
+  sram5_phdr PT_LOAD;
+  sram6_phdr PT_LOAD;
+  sram7_phdr PT_LOAD;
+  sram7_bss_phdr PT_LOAD;
+  log_phdr PT_LOAD;
+}
+
+
+/*  Default entry point:  */
+ENTRY(_ResetVector)
+
+
+/*  Memory boundary addresses:  */
+_memmap_mem_srom_start = 0x50000000;
+_memmap_mem_srom_end   = 0x51000000;
+_memmap_mem_sram_start = 0x60000000;
+_memmap_mem_sram_end   = 0x70000000;
+
+/*  Memory segment boundary addresses:  */
+_memmap_seg_srom0_start = 0x50000000;
+_memmap_seg_srom0_max   = 0x50000300;
+_memmap_seg_srom1_start = 0x50000300;
+_memmap_seg_srom1_max   = 0x50100000;
+_memmap_seg_sram0_start = 0x60000000;
+_memmap_seg_sram0_max   = 0x60000180;
+_memmap_seg_sram1_start = 0x60000180;
+_memmap_seg_sram1_max   = 0x600001c0;
+_memmap_seg_sram2_start = 0x600001c0;
+_memmap_seg_sram2_max   = 0x60000200;
+_memmap_seg_sram3_start = 0x60000200;
+_memmap_seg_sram3_max   = 0x60000240;
+_memmap_seg_sram4_start = 0x60000240;
+_memmap_seg_sram4_max   = 0x60000280;
+_memmap_seg_sram5_start = 0x60000280;
+_memmap_seg_sram5_max   = 0x60000300;
+_memmap_seg_sram6_start = 0x60000300;
+_memmap_seg_sram6_max   = 0x60000340;
+_memmap_seg_sram7_start = 0x60000340;
+_memmap_seg_sram7_max   = 0x60100000;
+_memmap_seg_log_start = 0x60100000;
+_memmap_seg_log_max   = 0x60300000;
+
+_rom_store_table = 0;
+PROVIDE(_memmap_reset_vector = 0x50000000);
+PROVIDE(_memmap_vecbase_reset = 0x60000000);
+/* Various memory-map dependent cache attribute settings: */
+_memmap_cacheattr_wb_base = 0x00001100;
+_memmap_cacheattr_wt_base = 0x00003300;
+_memmap_cacheattr_bp_base = 0x00004400;
+_memmap_cacheattr_unused_mask = 0xFFFF00FF;
+_memmap_cacheattr_wb_trapnull = 0x44441140;
+_memmap_cacheattr_wba_trapnull = 0x44441140;
+_memmap_cacheattr_wbna_trapnull = 0x44442240;
+_memmap_cacheattr_wt_trapnull = 0x44443340;
+_memmap_cacheattr_bp_trapnull = 0x44444440;
+_memmap_cacheattr_wb_strict = 0x00001100;
+_memmap_cacheattr_wt_strict = 0x00003300;
+_memmap_cacheattr_bp_strict = 0x00004400;
+_memmap_cacheattr_wb_allvalid = 0x44441144;
+_memmap_cacheattr_wt_allvalid = 0x44443344;
+_memmap_cacheattr_bp_allvalid = 0x44444444;
+_memmap_region_map = 0x0000000C;
+PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
+
+SECTIONS
+{
+
+  .ResetVector.text : ALIGN(4)
+  {
+    _ResetVector_text_start = ABSOLUTE(.);
+    KEEP (*(.ResetVector.text))
+    . = ALIGN (4);
+    _ResetVector_text_end = ABSOLUTE(.);
+    _memmap_seg_srom0_end = ALIGN(0x8);
+  } >srom0_seg :srom0_phdr
+
+
+  .srom.rodata : ALIGN(4)
+  {
+    _srom_rodata_start = ABSOLUTE(.);
+    *(.srom.rodata)
+    . = ALIGN (4);
+    _srom_rodata_end = ABSOLUTE(.);
+  } >srom1_seg :srom1_phdr
+
+  .srom.text : ALIGN(4)
+  {
+    _srom_text_start = ABSOLUTE(.);
+    *(.srom.literal .srom.text)
+    . = ALIGN (4);
+    _srom_text_end = ABSOLUTE(.);
+    _memmap_seg_srom1_end = ALIGN(0x8);
+  } >srom1_seg :srom1_phdr
+
+
+  .WindowVectors.text : ALIGN(4)
+  {
+    _WindowVectors_text_start = ABSOLUTE(.);
+    KEEP (*(.WindowVectors.text))
+    . = ALIGN (4);
+    _WindowVectors_text_end = ABSOLUTE(.);
+  } >sram0_seg :sram0_phdr
+
+  .Level2InterruptVector.literal : ALIGN(4)
+  {
+    _Level2InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level2InterruptVector.literal)
+    . = ALIGN (4);
+    _Level2InterruptVector_literal_end = ABSOLUTE(.);
+    _memmap_seg_sram0_end = ALIGN(0x8);
+  } >sram0_seg :sram0_phdr
+
+
+  .Level2InterruptVector.text : ALIGN(4)
+  {
+    _Level2InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level2InterruptVector.text))
+    . = ALIGN (4);
+    _Level2InterruptVector_text_end = ABSOLUTE(.);
+  } >sram1_seg :sram1_phdr
+
+  .DebugExceptionVector.literal : ALIGN(4)
+  {
+    _DebugExceptionVector_literal_start = ABSOLUTE(.);
+    *(.DebugExceptionVector.literal)
+    . = ALIGN (4);
+    _DebugExceptionVector_literal_end = ABSOLUTE(.);
+    _memmap_seg_sram1_end = ALIGN(0x8);
+  } >sram1_seg :sram1_phdr
+
+
+  .DebugExceptionVector.text : ALIGN(4)
+  {
+    _DebugExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.DebugExceptionVector.text))
+    . = ALIGN (4);
+    _DebugExceptionVector_text_end = ABSOLUTE(.);
+  } >sram2_seg :sram2_phdr
+
+  .NMIExceptionVector.literal : ALIGN(4)
+  {
+    _NMIExceptionVector_literal_start = ABSOLUTE(.);
+    *(.NMIExceptionVector.literal)
+    . = ALIGN (4);
+    _NMIExceptionVector_literal_end = ABSOLUTE(.);
+    _memmap_seg_sram2_end = ALIGN(0x8);
+  } >sram2_seg :sram2_phdr
+
+
+  .NMIExceptionVector.text : ALIGN(4)
+  {
+    _NMIExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.NMIExceptionVector.text))
+    . = ALIGN (4);
+    _NMIExceptionVector_text_end = ABSOLUTE(.);
+  } >sram3_seg :sram3_phdr
+
+  .KernelExceptionVector.literal : ALIGN(4)
+  {
+    _KernelExceptionVector_literal_start = ABSOLUTE(.);
+    *(.KernelExceptionVector.literal)
+    . = ALIGN (4);
+    _KernelExceptionVector_literal_end = ABSOLUTE(.);
+    _memmap_seg_sram3_end = ALIGN(0x8);
+  } >sram3_seg :sram3_phdr
+
+
+  .KernelExceptionVector.text : ALIGN(4)
+  {
+    _KernelExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.KernelExceptionVector.text))
+    . = ALIGN (4);
+    _KernelExceptionVector_text_end = ABSOLUTE(.);
+  } >sram4_seg :sram4_phdr
+
+  .UserExceptionVector.literal : ALIGN(4)
+  {
+    _UserExceptionVector_literal_start = ABSOLUTE(.);
+    *(.UserExceptionVector.literal)
+    . = ALIGN (4);
+    _UserExceptionVector_literal_end = ABSOLUTE(.);
+    _memmap_seg_sram4_end = ALIGN(0x8);
+  } >sram4_seg :sram4_phdr
+
+
+  .UserExceptionVector.text : ALIGN(4)
+  {
+    _UserExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.UserExceptionVector.text))
+    . = ALIGN (4);
+    _UserExceptionVector_text_end = ABSOLUTE(.);
+  } >sram5_seg :sram5_phdr
+
+  .DoubleExceptionVector.literal : ALIGN(4)
+  {
+    _DoubleExceptionVector_literal_start = ABSOLUTE(.);
+    *(.DoubleExceptionVector.literal)
+    . = ALIGN (4);
+    _DoubleExceptionVector_literal_end = ABSOLUTE(.);
+    _memmap_seg_sram5_end = ALIGN(0x8);
+  } >sram5_seg :sram5_phdr
+
+
+  .DoubleExceptionVector.text : ALIGN(4)
+  {
+    _DoubleExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.DoubleExceptionVector.text))
+    . = ALIGN (4);
+    _DoubleExceptionVector_text_end = ABSOLUTE(.);
+    _memmap_seg_sram6_end = ALIGN(0x8);
+  } >sram6_seg :sram6_phdr
+
+
+  .resource_table : ALIGN(4)
+  {
+    _resource_table_start = ABSOLUTE(.);
+    *(.resource_table)
+    . = ALIGN (4);
+    _resource_table_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .sram.rodata : ALIGN(4)
+  {
+    _sram_rodata_start = ABSOLUTE(.);
+    *(.sram.rodata)
+    . = ALIGN (4);
+    _sram_rodata_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .clib.rodata : ALIGN(4)
+  {
+    _clib_rodata_start = ABSOLUTE(.);
+    *(.clib.rodata)
+    . = ALIGN (4);
+    _clib_rodata_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .rtos.rodata : ALIGN(4)
+  {
+    _rtos_rodata_start = ABSOLUTE(.);
+    *(.rtos.rodata)
+    . = ALIGN (4);
+    _rtos_rodata_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .rodata : ALIGN(4)
+  {
+    _rodata_start = ABSOLUTE(.);
+    *(.rodata)
+    *(SORT(.rodata.sort.*))
+    KEEP (*(SORT(.rodata.keepsort.*) .rodata.keep.*))
+    *(.rodata.*)
+    *(.gnu.linkonce.r.*)
+    *(.rodata1)
+    __XT_EXCEPTION_TABLE__ = ABSOLUTE(.);
+    KEEP (*(.xt_except_table))
+    KEEP (*(.gcc_except_table))
+    *(.gnu.linkonce.e.*)
+    *(.gnu.version_r)
+    KEEP (*(.eh_frame))
+    /*  C++ constructor and destructor tables, properly ordered:  */
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    /*  C++ exception handlers table:  */
+    __XT_EXCEPTION_DESCS__ = ABSOLUTE(.);
+    *(.xt_except_desc)
+    *(.gnu.linkonce.h.*)
+    __XT_EXCEPTION_DESCS_END__ = ABSOLUTE(.);
+    *(.xt_except_desc_end)
+    *(.dynamic)
+    *(.gnu.version_d)
+    . = ALIGN(4);		/* this table MUST be 4-byte aligned */
+    _bss_table_start = ABSOLUTE(.);
+    LONG(_bss_start)
+    LONG(_bss_end)
+    _bss_table_end = ABSOLUTE(.);
+    . = ALIGN (4);
+    _rodata_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .sram.text : ALIGN(4)
+  {
+    _sram_text_start = ABSOLUTE(.);
+    *(.sram.literal .sram.text)
+    . = ALIGN (4);
+    _sram_text_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .text : ALIGN(4)
+  {
+    _stext = .;
+    _text_start = ABSOLUTE(.);
+    *(.entry.text)
+    *(.init.literal)
+    KEEP(*(.init))
+    *(.literal.sort.* SORT(.text.sort.*))
+    KEEP (*(.literal.keepsort.* SORT(.text.keepsort.*) .literal.keep.* .text.keep.* .literal.*personality* .text.*personality*))
+    *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    *(.fini.literal)
+    KEEP(*(.fini))
+    *(.gnu.version)
+    . = ALIGN (4);
+    _text_end = ABSOLUTE(.);
+    _etext = .;
+  } >sram7_seg :sram7_phdr
+
+  .clib.text : ALIGN(4)
+  {
+    _clib_text_start = ABSOLUTE(.);
+    *(.clib.literal .clib.text)
+    . = ALIGN (4);
+    _clib_text_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .rtos.text : ALIGN(4)
+  {
+    _rtos_text_start = ABSOLUTE(.);
+    *(.rtos.literal .rtos.text)
+    . = ALIGN (4);
+    _rtos_text_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .clib.data : ALIGN(4)
+  {
+    _clib_data_start = ABSOLUTE(.);
+    *(.clib.data)
+    . = ALIGN (4);
+    _clib_data_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .clib.percpu.data : ALIGN(4)
+  {
+    _clib_percpu_data_start = ABSOLUTE(.);
+    *(.clib.percpu.data)
+    . = ALIGN (4);
+    _clib_percpu_data_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .rtos.percpu.data : ALIGN(4)
+  {
+    _rtos_percpu_data_start = ABSOLUTE(.);
+    *(.rtos.percpu.data)
+    . = ALIGN (4);
+    _rtos_percpu_data_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .rtos.data : ALIGN(4)
+  {
+    _rtos_data_start = ABSOLUTE(.);
+    *(.rtos.data)
+    . = ALIGN (4);
+    _rtos_data_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .sram.data : ALIGN(4)
+  {
+    _sram_data_start = ABSOLUTE(.);
+    *(.sram.data)
+    . = ALIGN (4);
+    _sram_data_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .data : ALIGN(4)
+  {
+    _data_start = ABSOLUTE(.);
+    *(.data)
+    *(SORT(.data.sort.*))
+    KEEP (*(SORT(.data.keepsort.*) .data.keep.*))
+    *(.data.*)
+    *(.gnu.linkonce.d.*)
+    KEEP(*(.gnu.linkonce.d.*personality*))
+    *(.data1)
+    *(.sdata)
+    *(.sdata.*)
+    *(.gnu.linkonce.s.*)
+    *(.sdata2)
+    *(.sdata2.*)
+    *(.gnu.linkonce.s2.*)
+    KEEP(*(.jcr))
+    *(__llvm_prf_cnts)
+    *(__llvm_prf_data)
+    *(__llvm_prf_vnds)
+    . = ALIGN (4);
+    _data_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  __llvm_prf_names : ALIGN(4)
+  {
+    __llvm_prf_names_start = ABSOLUTE(.);
+    *(__llvm_prf_names)
+    . = ALIGN (4);
+    __llvm_prf_names_end = ABSOLUTE(.);
+  } >sram7_seg :sram7_phdr
+
+  .bss (NOLOAD) : ALIGN(8)
+  {
+    . = ALIGN (8);
+    _bss_start = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(SORT(.bss.sort.*))
+    KEEP (*(SORT(.bss.keepsort.*) .bss.keep.*))
+    *(.bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    *(.clib.bss)
+    *(.clib.percpu.bss)
+    *(.rtos.percpu.bss)
+    *(.rtos.bss)
+    *(.sram.bss)
+    . = ALIGN (8);
+    _bss_end = ABSOLUTE(.);
+    _end = ALIGN(0x8);
+    PROVIDE(end = ALIGN(0x8));
+    _stack_sentry = ALIGN(0x8);
+    _memmap_seg_sram7_end = ALIGN(0x8);
+  } >sram7_seg :sram7_bss_phdr
+
+  PROVIDE(__stack = 0x60100000);
+  _heap_sentry = 0x60100000;
+
+  .log : ALIGN(4)
+  {
+    _log_start = ABSOLUTE(.);
+    *(.log)
+    . = ALIGN (4);
+    _log_end = ABSOLUTE(.);
+    _memmap_seg_log_end = ALIGN(0x8);
+  } >log_seg :log_phdr
+
+  .debug  0 :  { *(.debug) }
+  .line  0 :  { *(.line) }
+  .debug_srcinfo  0 :  { *(.debug_srcinfo) }
+  .debug_sfnames  0 :  { *(.debug_sfnames) }
+  .debug_aranges  0 :  { *(.debug_aranges) }
+  .debug_pubnames  0 :  { *(.debug_pubnames) }
+  .debug_info  0 :  { *(.debug_info) }
+  .debug_abbrev  0 :  { *(.debug_abbrev) }
+  .debug_line  0 :  { *(.debug_line) }
+  .debug_frame  0 :  { *(.debug_frame) }
+  .debug_str  0 :  { *(.debug_str) }
+  .debug_loc  0 :  { *(.debug_loc) }
+  .debug_macinfo  0 :  { *(.debug_macinfo) }
+  .debug_weaknames  0 :  { *(.debug_weaknames) }
+  .debug_funcnames  0 :  { *(.debug_funcnames) }
+  .debug_typenames  0 :  { *(.debug_typenames) }
+  .debug_varnames  0 :  { *(.debug_varnames) }
+  .xt.insn 0 :
+  {
+    KEEP (*(.xt.insn))
+    KEEP (*(.gnu.linkonce.x.*))
+  }
+  .xt.prop 0 :
+  {
+    KEEP (*(.xt.prop))
+    KEEP (*(.xt.prop.*))
+    KEEP (*(.gnu.linkonce.prop.*))
+  }
+  .xt.lit 0 :
+  {
+    KEEP (*(.xt.lit))
+    KEEP (*(.xt.lit.*))
+    KEEP (*(.gnu.linkonce.p.*))
+  }
+  .debug.xt.callgraph 0 :
+  {
+    KEEP (*(.debug.xt.callgraph .debug.xt.callgraph.* .gnu.linkonce.xt.callgraph.*))
+  }
+}
+

--- a/test/system/generic/i500_apu/rsc_table.c
+++ b/test/system/generic/i500_apu/rsc_table.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019 - 2020, BayLibre SAS
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "rsc_table.h"
+
+#define IOMMU_READ		(1 << 0)
+#define IOMMU_WRITE		(1 << 1)
+#define IOMMU_CACHE		(1 << 2)
+#define IOMMU_NOEXEC		(1 << 3)
+#define IOMMU_MMIO		(1 << 4)
+
+struct remote_resource_table s_table
+	__attribute__((section(".resource_table"))) = {
+	.version = 1,
+	.num = NO_RESOURCE_ENTRIES,
+	.reserved = {0, 0},
+	.offset = {
+		offsetof(struct remote_resource_table, srom_hdr),
+		offsetof(struct remote_resource_table, sram_hdr),
+		offsetof(struct remote_resource_table, logbuf_hdr),
+		offsetof(struct remote_resource_table, trace_hdr),
+	},
+	.srom_hdr = {
+		.type = RSC_CARVEOUT,
+		.da = SROM_DA,
+		.pa = FW_RSC_ADDR_ANY,
+		.len = SROM_SIZE,
+		.flags = IOMMU_READ|IOMMU_WRITE,
+		.name = "System ROM",
+		.reserved = 0,
+	},
+	.sram_hdr = {
+		.type = RSC_CARVEOUT,
+		.da = SRAM_DA,
+		.pa = FW_RSC_ADDR_ANY,
+		.len = SRAM_SIZE,
+		.flags = IOMMU_READ|IOMMU_WRITE|IOMMU_NOEXEC,
+		.name = "System RAM",
+		.reserved = 0,
+	},
+	.logbuf_hdr = {
+		.type = RSC_CARVEOUT,
+		.da = LOG_BUFFER_DA,
+		.pa = FW_RSC_ADDR_ANY,
+		.len = LOG_BUFFER_SIZE,
+		.flags = IOMMU_READ|IOMMU_WRITE|IOMMU_NOEXEC,
+		.name = "Log buffer",
+		.reserved = 0,
+	},
+	.trace_hdr = {
+		.type = RSC_TRACE,
+		.da = LOG_BUFFER_DA, /* Log Buffer address */
+		.len = LOG_BUFFER_SIZE,
+		.name = "Trace",
+		.reserved = 0,
+	},
+};
+
+void *get_resource_table(int rsc_id, int *len)
+{
+	(void) rsc_id;
+	*len = sizeof(s_table);
+	return &s_table;
+}

--- a/test/system/generic/i500_apu/rsc_table.h
+++ b/test/system/generic/i500_apu/rsc_table.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2014, Mentor Graphics Corporation
+ * All rights reserved.
+ * Copyright (c) 2015 Xilinx, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef RSC_TABLE_H_
+#define RSC_TABLE_H_
+
+#include <openamp/remoteproc.h>
+
+#if defined __cplusplus
+extern "C" {
+#endif
+
+#define NO_RESOURCE_ENTRIES         4
+
+#define MB			(1024 * 1024)
+#define SROM_SIZE		(1 * MB)
+#define SRAM_SIZE		(1 * MB)
+#define LOG_BUFFER_SIZE		(1 * MB)
+
+#define SROM_DA			((uint32_t)&_memmap_mem_srom_start)
+#define SRAM_DA			((uint32_t)&_memmap_mem_sram_start)
+#define LOG_BUFFER_DA		((uint32_t)&_log_start)
+
+#define FW_RSC_ADDR_ANY		(-1)
+
+extern uint32_t _memmap_mem_srom_start;
+extern uint32_t _memmap_mem_sram_start;
+extern uint32_t _memmap_mem_sram_end;
+extern uint32_t _log_start;
+
+/* Resource table for the given remote */
+struct remote_resource_table {
+	unsigned int version;
+	unsigned int num;
+	unsigned int reserved[2];
+	unsigned int offset[NO_RESOURCE_ENTRIES];
+
+	struct fw_rsc_carveout srom_hdr;
+	struct fw_rsc_carveout sram_hdr;
+	struct fw_rsc_carveout stack_hdr;
+	struct fw_rsc_carveout logbuf_hdr;
+	struct fw_rsc_trace trace_hdr;
+} __packed __aligned(0x1000);
+
+void *get_resource_table(int rsc_id, int *len);
+
+#if defined __cplusplus
+}
+#endif
+
+#endif /* RSC_TABLE_H_ */

--- a/test/system/generic/i500_apu/specs
+++ b/test/system/generic/i500_apu/specs
@@ -1,0 +1,36 @@
+# Customer ID=12842; Build=0x69682; Copyright (c) 2001-2015 Cadence Design Systems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+# The %O suffix on the start and end files indicates that the system's
+# standard suffix for object files (e.g., ".o") should be appended.
+# The %s suffix tells the compiler driver to search for the file in the
+# list of known locations for startfiles.
+
+*startfile:
+crt1-boards%O%s crti%O%s crtbegin%O%s _sharedvectors%O%s _vectors%O%s
+
+*endfile:
+crtend%O%s crtn%O%s
+
+*lib:
+-lc -lgloss -lminrt -lc -lhandler-reset -lhandlers-board -lminrt -lhal -lc
+


### PR DESCRIPTION
Hello,

This pull request intends to add support of the AI Processing Unit (APU), a dual core VP6 (Xtensa LX7 ISA).
This just adds the minimum required for Rpmsg to work on the Mediatek i500 SoC.
Because there many other SoC or microcontroller using the Xtensa architecture, the support of xtensa and APU have been separated.

To build libmetal, gcc 10 could be used. Still this requires few additional low level libraries so I could provided a prebuilt toolchain for people interested (until I could fully document how to rebuild one).
XCC (Cadence complier) could also be used but this requires more cmake options to be configured.

For testing libmetal, we are building and running test-metal-static.
Currently, we can only load it on a real target, using remoteproc which add some constraints (e.g a resource table is required).
In addition, there are no uart so all the log must go to a log buffer.
I may try to use qemu or Candence ISS instead of real target as this would be more convenient for CI.

Thanks,
Alexandre