### PR TITLE
FreeRTOS: Allow tick rates greater than 1000 for metal_sleep_usec()

### DIFF
--- a/lib/system/freertos/sleep.h
+++ b/lib/system/freertos/sleep.h
@@ -25,7 +25,7 @@ extern "C" {
 
 static inline int __metal_sleep_usec(unsigned int usec)
 {
-	const TickType_t xDelay = ((usec/1000) / portTICK_PERIOD_MS);
+	const TickType_t xDelay = pdMS_TO_TICKS(usec/1000);
 
 	vTaskDelay(xDelay ? xDelay : 1);
 	return 0;


### PR DESCRIPTION
metal_sleep_usec() used portTICK_PERIOD_MS to determine how long to
sleep. If the FreeRTOS tick rate is set to greater than 1000, this
will be 0, resulting in a divide by zero error at run time. This changes
it to use pdMS_TO_TICKS(), which can accomodate higher tick rates.

Signed-off-by: Ed Mooring <ed.mooring@linaro.org>