### PR TITLE
Add symbols to library

### DIFF
--- a/lib/device.c
+++ b/lib/device.c
@@ -83,6 +83,9 @@ void metal_device_close(struct metal_device *device)
 		device->bus->ops.dev_close(device->bus, device);
 }
 
+extern struct metal_io_region *
+metal_device_io_region(struct metal_device *device, unsigned int index);
+
 int metal_register_generic_device(struct metal_device *device)
 {
 	if (!device->name || !strlen(device->name) ||

--- a/lib/device.h
+++ b/lib/device.h
@@ -143,7 +143,7 @@ extern void metal_device_close(struct metal_device *device);
  * @param[in]	index		Region index.
  * @return I/O accessor handle, or NULL on failure.
  */
-static inline struct metal_io_region *
+inline struct metal_io_region *
 metal_device_io_region(struct metal_device *device, unsigned int index)
 {
 	return (index < device->num_regions

--- a/lib/io.c
+++ b/lib/io.c
@@ -32,6 +32,26 @@ void metal_io_init(struct metal_io_region *io, void *virt,
 	metal_sys_io_mem_map(io);
 }
 
+extern void metal_io_finish(struct metal_io_region *io);
+
+extern size_t metal_io_region_size(struct metal_io_region *io);
+
+extern void *metal_io_virt(struct metal_io_region *io, unsigned long offset);
+
+extern unsigned long metal_io_virt_to_offset(struct metal_io_region *io, void *virt);
+
+extern metal_phys_addr_t metal_io_phys(struct metal_io_region *io, unsigned long offset);
+
+extern unsigned long metal_io_phys_to_offset(struct metal_io_region *io, metal_phys_addr_t phys);
+
+extern void * metal_io_phys_to_virt(struct metal_io_region *io, metal_phys_addr_t phys);
+
+extern metal_phys_addr_t metal_io_virt_to_phys(struct metal_io_region *io, void *virt);
+
+extern uint64_t metal_io_read(struct metal_io_region *io, unsigned long offset, memory_order order, int width);
+
+extern void metal_io_write(struct metal_io_region *io, unsigned long offset, uint64_t value, memory_order order, int width);
+
 int metal_io_block_read(struct metal_io_region *io, unsigned long offset,
 	       void *restrict dst, int len)
 {

--- a/lib/io.c
+++ b/lib/io.c
@@ -52,6 +52,66 @@ extern uint64_t metal_io_read(struct metal_io_region *io, unsigned long offset, 
 
 extern void metal_io_write(struct metal_io_region *io, unsigned long offset, uint64_t value, memory_order order, int width);
 
+extern uint8_t
+metal_io_read8_explicit(struct metal_io_region *io, unsigned long offset,
+	       memory_order order);
+
+extern uint8_t
+metal_io_read8(struct metal_io_region *io, unsigned long offset);
+
+extern uint16_t
+metal_io_read16_explicit(struct metal_io_region *io, unsigned long offset,
+	       memory_order order);
+
+extern uint16_t
+metal_io_read16(struct metal_io_region *io, unsigned long offset);
+
+extern uint32_t
+metal_io_read32_explicit(struct metal_io_region *io, unsigned long offset,
+	       memory_order order);
+
+extern uint32_t
+metal_io_read32(struct metal_io_region *io, unsigned long offset);
+
+extern uint64_t
+metal_io_read64_explicit(struct metal_io_region *io, unsigned long offset,
+	       memory_order order);
+
+extern uint64_t
+metal_io_read64(struct metal_io_region *io, unsigned long offset);
+
+extern void
+metal_io_write8_explicit(struct metal_io_region *io, unsigned long offset,
+	       uint8_t value, memory_order order);
+
+extern void
+metal_io_write8(struct metal_io_region *io, unsigned long offset,
+	       uint8_t value);
+
+extern void
+metal_io_write16_explicit(struct metal_io_region *io, unsigned long offset,
+	       uint16_t value, memory_order order);
+
+extern void
+metal_io_write16(struct metal_io_region *io, unsigned long offset,
+	       uint16_t value);
+
+extern void
+metal_io_write32_explicit(struct metal_io_region *io, unsigned long offset,
+	       uint32_t value, memory_order order);
+
+extern void
+metal_io_write32(struct metal_io_region *io, unsigned long offset,
+	       uint32_t value);
+
+extern void
+metal_io_write64_explicit(struct metal_io_region *io, unsigned long offset,
+	       uint64_t value, memory_order order);
+
+extern void
+metal_io_write64(struct metal_io_region *io, unsigned long offset,
+	       uint64_t value);
+
 int metal_io_block_read(struct metal_io_region *io, unsigned long offset,
 	       void *restrict dst, int len)
 {

--- a/lib/io.h
+++ b/lib/io.h
@@ -104,7 +104,7 @@ metal_io_init(struct metal_io_region *io, void *virt,
  * @brief	Close a libmetal shared memory segment.
  * @param[in]	io	I/O region handle.
  */
-static inline void metal_io_finish(struct metal_io_region *io)
+inline void metal_io_finish(struct metal_io_region *io)
 {
 	if (io->ops.close)
 		(*io->ops.close)(io);
@@ -117,7 +117,7 @@ static inline void metal_io_finish(struct metal_io_region *io)
  * @param[in]	io	I/O region handle.
  * @return	Size of I/O region.
  */
-static inline size_t metal_io_region_size(struct metal_io_region *io)
+inline size_t metal_io_region_size(struct metal_io_region *io)
 {
 	return io->size;
 }
@@ -128,7 +128,7 @@ static inline size_t metal_io_region_size(struct metal_io_region *io)
  * @param[in]	offset	Offset into shared memory segment.
  * @return	NULL if offset is out of range, or pointer to offset.
  */
-static inline void *
+inline void *
 metal_io_virt(struct metal_io_region *io, unsigned long offset)
 {
 	return (io->virt != METAL_BAD_VA && offset < io->size
@@ -142,7 +142,7 @@ metal_io_virt(struct metal_io_region *io, unsigned long offset)
  * @param[in]	virt	Virtual address within segment.
  * @return	METAL_BAD_OFFSET if out of range, or offset.
  */
-static inline unsigned long
+inline unsigned long
 metal_io_virt_to_offset(struct metal_io_region *io, void *virt)
 {
 	size_t offset = (uint8_t *)virt - (uint8_t *)io->virt;
@@ -157,7 +157,7 @@ metal_io_virt_to_offset(struct metal_io_region *io, void *virt)
  * @return	METAL_BAD_PHYS if offset is out of range, or physical address
  *		of offset.
  */
-static inline metal_phys_addr_t
+inline metal_phys_addr_t
 metal_io_phys(struct metal_io_region *io, unsigned long offset)
 {
 	if (!io->ops.offset_to_phys) {
@@ -178,7 +178,7 @@ metal_io_phys(struct metal_io_region *io, unsigned long offset)
  * @param[in]	phys	Physical address within segment.
  * @return	METAL_BAD_OFFSET if out of range, or offset.
  */
-static inline unsigned long
+inline unsigned long
 metal_io_phys_to_offset(struct metal_io_region *io, metal_phys_addr_t phys)
 {
 	if (!io->ops.phys_to_offset) {
@@ -202,7 +202,7 @@ metal_io_phys_to_offset(struct metal_io_region *io, metal_phys_addr_t phys)
  * @param[in]	phys	Physical address within segment.
  * @return	NULL if out of range, or corresponding virtual address.
  */
-static inline void *
+inline void *
 metal_io_phys_to_virt(struct metal_io_region *io, metal_phys_addr_t phys)
 {
 	return metal_io_virt(io, metal_io_phys_to_offset(io, phys));
@@ -215,7 +215,7 @@ metal_io_phys_to_virt(struct metal_io_region *io, metal_phys_addr_t phys)
  * @return	METAL_BAD_PHYS if out of range, or corresponding
  *		physical address.
  */
-static inline metal_phys_addr_t
+inline metal_phys_addr_t
 metal_io_virt_to_phys(struct metal_io_region *io, void *virt)
 {
 	return metal_io_phys(io, metal_io_virt_to_offset(io, virt));
@@ -231,7 +231,7 @@ metal_io_virt_to_phys(struct metal_io_region *io, void *virt)
  *			to inline cleanly.
  * @return	Value.
  */
-static inline uint64_t
+inline uint64_t
 metal_io_read(struct metal_io_region *io, unsigned long offset,
 	      memory_order order, int width)
 {
@@ -265,7 +265,7 @@ metal_io_read(struct metal_io_region *io, unsigned long offset,
  *			4, or 8, and a compile time constant for this function
  *			to inline cleanly.
  */
-static inline void
+inline void
 metal_io_write(struct metal_io_region *io, unsigned long offset,
 	       uint64_t value, memory_order order, int width)
 {

--- a/lib/io.h
+++ b/lib/io.h
@@ -355,7 +355,7 @@ metal_io_write8_explicit(struct metal_io_region *io, unsigned long offset,
 }
 
 inline void
-metal_io_write8_explicit(struct metal_io_region *io, unsigned long offset,
+metal_io_write8(struct metal_io_region *io, unsigned long offset,
 	       uint8_t value)
 {
 	metal_io_write(io, offset, value, memory_order_seq_cst, 1);
@@ -369,7 +369,7 @@ metal_io_write16_explicit(struct metal_io_region *io, unsigned long offset,
 }
 
 inline void
-metal_io_write16_explicit(struct metal_io_region *io, unsigned long offset,
+metal_io_write16(struct metal_io_region *io, unsigned long offset,
 	       uint16_t value)
 {
 	metal_io_write(io, offset, value, memory_order_seq_cst, 2);
@@ -383,7 +383,7 @@ metal_io_write32_explicit(struct metal_io_region *io, unsigned long offset,
 }
 
 inline void
-metal_io_write32_explicit(struct metal_io_region *io, unsigned long offset,
+metal_io_write32(struct metal_io_region *io, unsigned long offset,
 	       uint32_t value)
 {
 	metal_io_write(io, offset, value, memory_order_seq_cst, 4);
@@ -397,7 +397,7 @@ metal_io_write64_explicit(struct metal_io_region *io, unsigned long offset,
 }
 
 inline void
-metal_io_write64_explicit(struct metal_io_region *io, unsigned long offset,
+metal_io_write64(struct metal_io_region *io, unsigned long offset,
 	       uint64_t value)
 {
 	metal_io_write(io, offset, value, memory_order_seq_cst, 8);

--- a/lib/io.h
+++ b/lib/io.h
@@ -294,41 +294,114 @@ metal_io_write(struct metal_io_region *io, unsigned long offset,
 		metal_assert(0);
 }
 
-#define metal_io_read8_explicit(_io, _ofs, _order)			\
-	metal_io_read((_io), (_ofs), (_order), 1)
-#define metal_io_read8(_io, _ofs)					\
-	metal_io_read((_io), (_ofs), memory_order_seq_cst, 1)
-#define metal_io_write8_explicit(_io, _ofs, _val, _order)		\
-	metal_io_write((_io), (_ofs), (_val), (_order), 1)
-#define metal_io_write8(_io, _ofs, _val)				\
-	metal_io_write((_io), (_ofs), (_val), memory_order_seq_cst, 1)
+inline uint8_t
+metal_io_read8_explicit(struct metal_io_region *io, unsigned long offset,
+	       memory_order order)
+{
+	return metal_io_read(io, offset, order, 1);
+}
 
-#define metal_io_read16_explicit(_io, _ofs, _order)			\
-	metal_io_read((_io), (_ofs), (_order), 2)
-#define metal_io_read16(_io, _ofs)					\
-	metal_io_read((_io), (_ofs), memory_order_seq_cst, 2)
-#define metal_io_write16_explicit(_io, _ofs, _val, _order)		\
-	metal_io_write((_io), (_ofs), (_val), (_order), 2)
-#define metal_io_write16(_io, _ofs, _val)				\
-	metal_io_write((_io), (_ofs), (_val), memory_order_seq_cst, 2)
+inline uint8_t
+metal_io_read8(struct metal_io_region *io, unsigned long offset)
+{
+	return metal_io_read(io, offset, memory_order_seq_cst, 1);
+}
 
-#define metal_io_read32_explicit(_io, _ofs, _order)			\
-	metal_io_read((_io), (_ofs), (_order), 4)
-#define metal_io_read32(_io, _ofs)					\
-	metal_io_read((_io), (_ofs), memory_order_seq_cst, 4)
-#define metal_io_write32_explicit(_io, _ofs, _val, _order)		\
-	metal_io_write((_io), (_ofs), (_val), (_order), 4)
-#define metal_io_write32(_io, _ofs, _val)				\
-	metal_io_write((_io), (_ofs), (_val), memory_order_seq_cst, 4)
+inline uint16_t
+metal_io_read16_explicit(struct metal_io_region *io, unsigned long offset,
+	       memory_order order)
+{
+	return metal_io_read(io, offset, order, 2);
+}
 
-#define metal_io_read64_explicit(_io, _ofs, _order)			\
-	metal_io_read((_io), (_ofs), (_order), 8)
-#define metal_io_read64(_io, _ofs)					\
-	metal_io_read((_io), (_ofs), memory_order_seq_cst, 8)
-#define metal_io_write64_explicit(_io, _ofs, _val, _order)		\
-	metal_io_write((_io), (_ofs), (_val), (_order), 8)
-#define metal_io_write64(_io, _ofs, _val)				\
-	metal_io_write((_io), (_ofs), (_val), memory_order_seq_cst, 8)
+inline uint16_t
+metal_io_read16(struct metal_io_region *io, unsigned long offset)
+{
+	return metal_io_read(io, offset, memory_order_seq_cst, 2);
+}
+
+inline uint32_t
+metal_io_read32_explicit(struct metal_io_region *io, unsigned long offset,
+	       memory_order order)
+{
+	return metal_io_read(io, offset, order, 4);
+}
+
+inline uint32_t
+metal_io_read32(struct metal_io_region *io, unsigned long offset)
+{
+	return metal_io_read(io, offset, memory_order_seq_cst, 4);
+}
+
+inline uint64_t
+metal_io_read64_explicit(struct metal_io_region *io, unsigned long offset,
+	       memory_order order)
+{
+	return metal_io_read(io, offset, order, 8);
+}
+
+inline uint64_t
+metal_io_read64(struct metal_io_region *io, unsigned long offset)
+{
+	return metal_io_read(io, offset, memory_order_seq_cst, 8);
+}
+
+
+inline void
+metal_io_write8_explicit(struct metal_io_region *io, unsigned long offset,
+	       uint8_t value, memory_order order)
+{
+	metal_io_write(io, offset, value, order, 1);
+}
+
+inline void
+metal_io_write8_explicit(struct metal_io_region *io, unsigned long offset,
+	       uint8_t value)
+{
+	metal_io_write(io, offset, value, memory_order_seq_cst, 1);
+}
+
+inline void
+metal_io_write16_explicit(struct metal_io_region *io, unsigned long offset,
+	       uint16_t value, memory_order order)
+{
+	metal_io_write(io, offset, value, order, 2);
+}
+
+inline void
+metal_io_write16_explicit(struct metal_io_region *io, unsigned long offset,
+	       uint16_t value)
+{
+	metal_io_write(io, offset, value, memory_order_seq_cst, 2);
+}
+
+inline void
+metal_io_write32_explicit(struct metal_io_region *io, unsigned long offset,
+	       uint32_t value, memory_order order)
+{
+	metal_io_write(io, offset, value, order, 4);
+}
+
+inline void
+metal_io_write32_explicit(struct metal_io_region *io, unsigned long offset,
+	       uint32_t value)
+{
+	metal_io_write(io, offset, value, memory_order_seq_cst, 4);
+}
+
+inline void
+metal_io_write64_explicit(struct metal_io_region *io, unsigned long offset,
+	       uint64_t value, memory_order order)
+{
+	metal_io_write(io, offset, value, order, 8);
+}
+
+inline void
+metal_io_write64_explicit(struct metal_io_region *io, unsigned long offset,
+	       uint64_t value)
+{
+	metal_io_write(io, offset, value, memory_order_seq_cst, 8);
+}
 
 /**
  * @brief	Read a block from an I/O region.


### PR DESCRIPTION
Work to address #156 

In addition to #defines, static inline functions have no symbols in compiled library. This PR also addresses the more obvious candidates here.