### PR TITLE
io: add null pointer check in io block ops

### DIFF
--- a/lib/io.c
+++ b/lib/io.c
@@ -39,7 +39,7 @@ int metal_io_block_read(struct metal_io_region *io, unsigned long offset,
 	unsigned char *dest = dst;
 	int retlen;
 
-	if (offset >= io->size)
+	if (!ptr)
 		return -ERANGE;
 	if ((offset + len) > io->size)
 		len = io->size - offset;
@@ -76,7 +76,7 @@ int metal_io_block_write(struct metal_io_region *io, unsigned long offset,
 	const unsigned char *source = src;
 	int retlen;
 
-	if (offset >= io->size)
+	if (!ptr)
 		return -ERANGE;
 	if ((offset + len) > io->size)
 		len = io->size - offset;
@@ -112,7 +112,7 @@ int metal_io_block_set(struct metal_io_region *io, unsigned long offset,
 	unsigned char *ptr = metal_io_virt(io, offset);
 	int retlen = len;
 
-	if (offset >= io->size)
+	if (!ptr)
 		return -ERANGE;
 	if ((offset + len) > io->size)
 		len = io->size - offset;


### PR DESCRIPTION
metal_io_virt returns NULL on invalid input metal_io_region.
Check ptr before use it.

Signed-off-by: Mark-PK Tsai <mark-pk.tsai@mediatek.com>