### PR TITLE
io: add overflow check in metal_io_phys_to_offset

### DIFF
--- a/lib/io.h
+++ b/lib/io.h
@@ -188,6 +188,11 @@ metal_io_phys_to_offset(struct metal_io_region *io, metal_phys_addr_t phys)
 		do {
 			if (metal_io_phys(io, offset) == phys)
 				return offset;
+
+			if (offset + io->page_mask + 1 <= offset)
+				/* Overflow */
+				break;
+
 			offset += io->page_mask + 1;
 		} while (offset < io->size);
 		return METAL_BAD_OFFSET;


### PR DESCRIPTION
Return METAL_BAD_OFFSET if offset overflow in the phys
searching loop.
This issue is reported by coverity.

Signed-off-by: Mark-PK Tsai <mark-pk.tsai@mediatek.com>