### PR TITLE
openamp/libmetal: fix Non-zero offsets to null pointers

### DIFF
--- a/lib/io.h
+++ b/lib/io.h
@@ -132,7 +132,7 @@ static inline void *
 metal_io_virt(struct metal_io_region *io, unsigned long offset)
 {
 	return (io->virt != METAL_BAD_VA && offset < io->size
-		? (uint8_t *)io->virt + offset
+		? (void *)((uintptr_t)io->virt + offset)
 		: NULL);
 }
 
@@ -145,7 +145,7 @@ metal_io_virt(struct metal_io_region *io, unsigned long offset)
 static inline unsigned long
 metal_io_virt_to_offset(struct metal_io_region *io, void *virt)
 {
-	size_t offset = (uint8_t *)virt - (uint8_t *)io->virt;
+	size_t offset = (uintptr_t)virt - (uintptr_t)io->virt;
 
 	return (offset < io->size ? offset : METAL_BAD_OFFSET);
 }

--- a/lib/system/nuttx/io.c
+++ b/lib/system/nuttx/io.c
@@ -75,13 +75,13 @@ static void metal_io_close_(struct metal_io_region *io)
 static metal_phys_addr_t metal_io_offset_to_phys_(struct metal_io_region *io,
 						  unsigned long offset)
 {
-	return up_addrenv_va_to_pa((char *)io->virt + offset);
+	return up_addrenv_va_to_pa((uintptr_t)io->virt + offset);
 }
 
 static unsigned long metal_io_phys_to_offset_(struct metal_io_region *io,
 					      metal_phys_addr_t phys)
 {
-	return (char *)up_addrenv_pa_to_va(phys) - (char *)io->virt;
+	return (uintptr_t)up_addrenv_pa_to_va(phys) - (uintptr_t)io->virt;
 }
 
 static metal_phys_addr_t metal_io_phys_start_;


### PR DESCRIPTION
leads to ASAN errors
libmetal/lib/system/nuttx/io.c:78:9: runtime error: applying non-zero offset 4124131344 to null pointer
metal/io.h:136:3: runtime error: applying non-zero offset 4124131440 to null pointer
metal/io.h:136:3: runtime error: applying non-zero offset 4124131440 to null pointer
metal/io.h:136:3: runtime error: applying non-zero offset 4124131440 to null pointer
metal/io.h:136:3: runtime error: applying non-zero offset 4124131552 to null pointer
metal/io.h:136:3: runtime error: applying non-zero offset 4124132000 to null pointer
==15484==WARNING: ASan is ignoring requested __asan_handle_no_return: stack top: 0xffd3c000; bottom 0xf3437000; size: 0x0c905000 (210784256)
False positive error reports may follow
For details see https://github.com/google/sanitizers/issues/189
