### PR TITLE
CI: Fix Zephyr build by updating Zephyr SDK version to 13.0

### DIFF
--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -4,9 +4,9 @@ readonly TARGET="$1"
 
 ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 ZEPHYR_SDK_INSTALL_DIR=/opt/zephyr-sdk
-ZEPHYR_SDK_VERSION=0.12.4
+ZEPHYR_SDK_VERSION=0.13.0
 ZEPHYR_SDK_DOWNLOAD_FOLDER=https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v$ZEPHYR_SDK_VERSION
-ZEPHYR_SDK_SETUP_BINARY=zephyr-sdk-$ZEPHYR_SDK_VERSION-x86_64-linux-setup.run
+ZEPHYR_SDK_SETUP_BINARY=zephyr-sdk-$ZEPHYR_SDK_VERSION-linux-x86_64-setup.run
 ZEPHYR_SDK_DOWNLOAD_URL=$ZEPHYR_SDK_DOWNLOAD_FOLDER/$ZEPHYR_SDK_SETUP_BINARY
 
 FREERTOS_ZIP_URL=https://cfhcable.dl.sourceforge.net/project/freertos/FreeRTOS/V10.0.1/FreeRTOSv10.0.1.zip


### PR DESCRIPTION
Update zephyr SDK to 0.13 to fix CI compatibility issue.
The name of the steup file has also be updated.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@foss.st.com>