### PR TITLE
CI: Fix Zephyr build error due to cmake version

### DIFF
--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -16,7 +16,8 @@ pre_build(){
 	echo 'Etc/UTC' > /etc/timezone &&
 	ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime &&
 	apt update &&
-   	apt-get install -y cmake make
+   	apt-get install -y make || exit 1
+   	sudo pip3 install cmake || exit 1
 }
 
 build_linux(){


### PR DESCRIPTION
CMake 3.20.0 or higher is required by Zephyr.
Use pip3 as recommended by zephyr project to get the last version.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@foss.st.com>