### PR TITLE
freertos: io: fix IAR compile error due to 'void *' variable

### DIFF
--- a/lib/system/freertos/io.c
+++ b/lib/system/freertos/io.c
@@ -15,10 +15,10 @@ void metal_sys_io_mem_map(struct metal_io_region *io)
 {
 	unsigned long p;
 	size_t psize;
-	void *va;
+	size_t *va;
 
 	va = io->virt;
-	psize = io->size;
+	psize = (size_t)io->size;
 	if (psize) {
 		if (psize >> io->page_shift)
 			psize = (size_t)1 << io->page_shift;


### PR DESCRIPTION
Fix EWARM compilation error due to void pointer usage.
This fix has already been implemented for the generic system (https://github.com/OpenAMP/libmetal/commit/4081b0d562380b635f6e1436bd8e57cea6b3a792) but
was missing for the FreeRTOS.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>