### PR TITLE
test: fix cmake warning: "Policy CMP0115 is not set"

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,9 +68,9 @@ else (WITH_ZEPHYR)
   foreach (INCLUDE ${_headers})
     string (REGEX REPLACE "[^a-zA-Z0-9]+" "-" _f ${INCLUDE})
     configure_file (metal-header-template.c ${_f}.c)
-    list (APPEND _flist "${CMAKE_CURRENT_BINARY_DIR}/${_f}")
+    list (APPEND _flist "${CMAKE_CURRENT_BINARY_DIR}/${_f}.c")
   endforeach (INCLUDE)
-  add_library (metal-headers STATIC ${_flist})
+add_library (metal-headers STATIC ${_flist})
 endif (WITH_ZEPHYR)
 
 # vim: expandtab:ts=2:sw=2:smartindent


### PR DESCRIPTION
add .c file extension to build/test/metal-xxx-h generated file as
recommended by the Policy CMP0115

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@foss.st.com>