### PR TITLE
libmeatal: fix warning

### DIFF
--- a/lib/system/nuttx/io.c
+++ b/lib/system/nuttx/io.c
@@ -75,7 +75,7 @@ static void metal_io_close_(struct metal_io_region *io)
 static metal_phys_addr_t metal_io_offset_to_phys_(struct metal_io_region *io,
 						  unsigned long offset)
 {
-	return up_addrenv_va_to_pa((uintptr_t)io->virt + offset);
+	return up_addrenv_va_to_pa((void *)((uintptr_t)io->virt + offset));
 }
 
 static unsigned long metal_io_phys_to_offset_(struct metal_io_region *io,


### PR DESCRIPTION
```
libmetal/lib/system/nuttx/io.c: In function ‘metal_io_offset_to_phys_’:
libmetal/lib/system/nuttx/io.c:78:49: warning: passing argument 1 of ‘up_addrenv_va_to_pa’ makes pointer from integer without a cast [-Wint-conversion]
   78 |  return up_addrenv_va_to_pa((uintptr_t)io->virt + offset);
      |                             ~~~~~~~~~~~~~~~~~~~~^~~~~~~~
      |                                                 |
      |                                                 long unsigned int
In file included from /home/ligd/platform/miwear/ap/nuttx/include/metal/system/nuttx/cache.h:19,
                 from /home/ligd/platform/miwear/ap/nuttx/include/metal/cache.h:15,
                 from libmetal/lib/system/nuttx/io.c:7:
/home/ligd/platform/miwear/ap/nuttx/include/nuttx/arch.h:1319:41: note: expected ‘void *’ but argument is of type ‘long unsigned int’
 1319 | uintptr_t up_addrenv_va_to_pa(FAR void *va);
      |                                   ~~~~~~^~
```
