### PR TITLE
libmetal: Compiles for petalinux microblazeel.

### DIFF
--- a/lib/processor/microblazeel/CMakeLists.txt
+++ b/lib/processor/microblazeel/CMakeLists.txt
@@ -1,0 +1,4 @@
+collect (PROJECT_LIB_HEADERS atomic.h)
+collect (PROJECT_LIB_HEADERS cpu.h)
+collect (PROJECT_LIB_DEPS atomic)
+# vim: expandtab:ts=2:sw=2:smartindent

--- a/lib/processor/microblazeel/atomic.h
+++ b/lib/processor/microblazeel/atomic.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	microblaze/atomic.h
+ * @brief	Microblaze specific atomic primitives for libmetal
+ */
+
+#ifndef __METAL_MICROBLAZE_ATOMIC__H__
+#define __METAL_MICROBLAZE_ATOMIC__H__
+
+#endif /* __METAL_MICROBLAZE_ATOMIC__H__ */

--- a/lib/processor/microblazeel/cpu.h
+++ b/lib/processor/microblazeel/cpu.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	cpu.h
+ * @brief	CPU specific primatives on microblaze platform.
+ */
+
+#ifndef __METAL_MICROBLAZE__H__
+#define __METAL_MICROBLAZE__H__
+
+#include <stdint.h>
+#include <metal/atomic.h>
+
+#define metal_cpu_yield()
+
+#endif /* __METAL_MICROBLAZE__H__ */


### PR DESCRIPTION
Not sure if this is needed / wanted.
I got libmetal to compile for microblaze 2020.2 by adding the atomic library to required libs.
I also had to copy the folder from microblaze to microblazeel.

I built by
source /opt/petalinux/2020.2/environment-setup-microblazeel-v11.0-bs-cmp-re-mh-div-xilinx-linux
mkdir -p libmetal/build
cd libmetal/build
cmake ..
make
