### PR TITLE
metal_init: Add a flag to indicate that internal data is initialized.

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -24,11 +24,15 @@ int metal_init(const struct metal_init_params *params)
 	if (error)
 		return error;
 
+	_metal.common.initialized = 1;
 	return error;
 }
 
 void metal_finish(void)
 {
+	/* if metal_init() failed, or metal_finish() is called twice, just return */
+	if (!_metal.common.initialized)
+		return;
 	metal_sys_finish();
 	memset(&_metal, 0, sizeof(_metal));
 }

--- a/lib/sys.h
+++ b/lib/sys.h
@@ -67,6 +67,9 @@ struct metal_common_state {
 	/** Current log handler (null for none). */
 	metal_log_handler		log_handler;
 
+	/** Has the structure been initialized? */
+	int initialized;
+
 	/** List of registered buses. */
 	struct metal_list		bus_list;
 


### PR DESCRIPTION
Linux users have been seeing segfaults in libmetal when metal_finish()
is called twice after a successful initialization, or on exit afer
an unsuccessful initialization. This adds a field to metal_common_state
that is set on initialization. metal_finish() sets the entire structure,
including this field to zero. metal_finish() now also checks this flag
before attempting to shutdown libmetal.