### PR TITLE
Add support for registering interrupts on Zephyr

### DIFF
--- a/lib/system/zephyr/init.c
+++ b/lib/system/zephyr/init.c
@@ -17,6 +17,11 @@ struct metal_state _metal;
 
 int metal_sys_init(const struct metal_init_params *params)
 {
+	int ret;
+
+	ret = metal_zephyr_irq_init();
+	if (ret)
+		return ret;
 	metal_bus_register(&metal_generic_bus);
 	return 0;
 }

--- a/lib/system/zephyr/irq.c
+++ b/lib/system/zephyr/irq.c
@@ -10,6 +10,7 @@
  */
 
 #include <metal/errno.h>
+#include <metal/irq_controller.h>
 #include <metal/irq.h>
 #include <metal/sys.h>
 #include <metal/log.h>
@@ -17,6 +18,12 @@
 #include <metal/list.h>
 #include <metal/utilities.h>
 #include <metal/alloc.h>
+
+#ifdef CONFIG_DYNAMIC_INTERRUPTS
+#define MAX_IRQS CONFIG_NUM_IRQS
+
+static struct metal_irq irqs[MAX_IRQS];
+#endif /* CONFIG_DYNAMIC_INTERRUPTS */
 
 unsigned int metal_irq_save_disable(void)
 {
@@ -28,3 +35,60 @@ void metal_irq_restore_enable(unsigned int flags)
 	irq_unlock(flags);
 }
 
+#ifdef CONFIG_DYNAMIC_INTERRUPTS
+static void metal_zephyr_irq_set_enable(struct metal_irq_controller *irq_cntr,
+				     int irq, unsigned int state)
+{
+	if (irq < irq_cntr->irq_base ||
+	    irq >= irq_cntr->irq_base + irq_cntr->irq_num) {
+		metal_log(METAL_LOG_ERROR,
+			  "%s: invalid irq %d\n", __func__, irq);
+		return;
+	} else if (state == METAL_IRQ_ENABLE) {
+		irq_enable(irq);
+	} else {
+		irq_disable(irq);
+	}
+}
+
+static void metal_zephyr_irq_isr(const void *arg)
+{
+	unsigned int vector = (unsigned int) arg;
+
+	if (vector >= MAX_IRQS) {
+		return;
+	}
+	(void) metal_irq_handle(&irqs[vector], (int)vector);
+}
+
+static int metal_zephyr_irq_register(struct metal_irq_controller *cntr, int irq,
+				     metal_irq_handler hd, void *arg)
+{
+	irqs[irq].hd = hd;
+	irqs[irq].arg = arg;
+	irq_connect_dynamic(irq, 0, metal_zephyr_irq_isr, (void *)irq, 0);
+	return 0;
+}
+
+static METAL_IRQ_CONTROLLER_DECLARE(zephyr_irq_cntr,
+				    0, MAX_IRQS,
+				    NULL,
+				    metal_zephyr_irq_set_enable,
+				    metal_zephyr_irq_register,
+				    irqs);
+#endif	/* CONFIG_DYNAMIC_INTERRUPTS */
+
+int metal_zephyr_irq_init(void)
+{
+#ifdef CONFIG_DYNAMIC_INTERRUPTS
+	int ret;
+
+	ret =  metal_irq_register_controller(&zephyr_irq_cntr);
+	if (ret < 0) {
+		metal_log(METAL_LOG_ERROR,
+			  "%s: register irq controller failed.\n", __func__);
+		return ret;
+	}
+#endif	/* CONFIG_DYNAMIC_INTERRUPTS */
+	return 0;
+}

--- a/lib/system/zephyr/sys.h
+++ b/lib/system/zephyr/sys.h
@@ -41,6 +41,17 @@ struct metal_state {
 	struct metal_common_state common;
 };
 
+/**
+ * @brief	metal_zephyr_irq_init
+ *
+ * Initialize the metal IRQ controller abstraction.
+ *
+ * @return 0 for success, or negative value for failure.
+ *
+ * @return 0 for success, or negative value for failure
+ */
+int metal_zephyr_irq_init(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR simply wires metal interrupt APIs to the Zephyr APIs.