### PR TITLE
Fix various typos

### DIFF
--- a/.github/actions/build_ci/README.md
+++ b/.github/actions/build_ci/README.md
@@ -7,7 +7,7 @@ This action test builds for a specified target.
 ### `target`
 
 **Required** the build target. Default `"linux"`.
-The supported taget are:
+The supported targets are:
   linux
   generic arm
   freertos

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ own project.
 
 * **WITH_DOC** (default ON): Build with documentation. Add -DWITH_DOC=OFF in
 cmake command line to disable.
-* **WITH_EXAMPLES** (default ON): Build with application exemples. Add
+* **WITH_EXAMPLES** (default ON): Build with application examples. Add
 -DWITH_DOC=OFF in cmake command line to disable the option.
 * **WITH_TESTS** (default ON): Build with application tests. Add -DWITH_DOC=OFF
 in cmake command line to disable the option.
@@ -231,7 +231,7 @@ handler registered by the user application.
 libmetal provides APIs to flush and invalidate caches.
 
 The cache APIs for Linux userspace are empty functions for now as cache
-operations system calls are not avaiable for all architectures.
+operations system calls are not available for all architectures.
 
 ### DMA
 

--- a/cmake/platforms/template-freertos.cmake
+++ b/cmake/platforms/template-freertos.cmake
@@ -1,4 +1,4 @@
-# Modify to match your needs.  These setttings can also be overridden at the
+# Modify to match your needs.  These settings can also be overridden at the
 # command line.  (eg. cmake -DCMAKE_C_FLAGS="-O3")
 
 set (CMAKE_SYSTEM_PROCESSOR "arm"            CACHE STRING "")

--- a/cmake/platforms/template-generic.cmake
+++ b/cmake/platforms/template-generic.cmake
@@ -1,4 +1,4 @@
-# Modify to match your needs.  These setttings can also be overridden at the
+# Modify to match your needs.  These settings can also be overridden at the
 # command line.  (eg. cmake -DCMAKE_C_FLAGS="-O3")
 
 set (CMAKE_SYSTEM_PROCESSOR "arm"            CACHE STRING "")

--- a/cmake/platforms/zynqmp-r5-generic.cmake
+++ b/cmake/platforms/zynqmp-r5-generic.cmake
@@ -2,7 +2,7 @@ set (CMAKE_SYSTEM_PROCESSOR "arm"              CACHE STRING "")
 set (MACHINE                "zynqmp_r5"        CACHE STRING "")
 set (CROSS_PREFIX           "armr5-none-eabi-" CACHE STRING "")
 
-# Xilinx SDK version earlier than 2017.2 use mfloat-abi=soft by default to generat libxil
+# Xilinx SDK version earlier than 2017.2 use mfloat-abi=soft by default to generate libxil
 set (CMAKE_C_FLAGS          "-mfloat-abi=hard -mfpu=vfpv3-d16 -mcpu=cortex-r5" CACHE STRING "")
 
 include (cross-generic-gcc)

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/common.h
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/common.h
@@ -34,7 +34,7 @@
 #define IPI_ISR_OFFSET  0x10 /* IPI interrupt status reg offset */
 #define IPI_IMR_OFFSET  0x14 /* IPI interrupt mask reg offset */
 #define IPI_IER_OFFSET  0x18 /* IPI interrupt enable reg offset */
-#define IPI_IDR_OFFSET  0x1C /* IPI interrup disable reg offset */
+#define IPI_IDR_OFFSET  0x1C /* IPI interrupt disable reg offset */
 
 #define IPI_MASK        0x1000000 /* IPI mask for kick from APU.
 				     We use PL0 IPI in this demo. */
@@ -139,7 +139,7 @@ static inline void wait_for_interrupt()
 }
 
 /**
- * @breif wait_for_notified() - Loop until notified bit
+ * @brief wait_for_notified() - Loop until notified bit
  *        in channel is set.
  *
  * @param[in] notified - pointer to the notified variable

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/ipi_latency_demod.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/ipi_latency_demod.c
@@ -7,7 +7,7 @@
 /*****************************************************************************
  * ipi_latency_demod.c
  * This is the remote side of the IPI latency measurement demo.
- * This demo does the follwing steps:
+ * This demo does the following steps:
  *
  *  1. Open the shared memory device.
  *  1. Open the TTC timer device.

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_latency_demod.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_latency_demod.c
@@ -7,7 +7,7 @@
 /*****************************************************************************
  * shmem_latency_demod.c
  * This is the remote side of the IPI latency measurement demo.
- * This demo does the follwing steps:
+ * This demo does the following steps:
  *
  *  1. Get the shared memory device libmetal I/O region.
  *  1. Get the TTC timer device libemtal I/O region.

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_throughput_demod.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_throughput_demod.c
@@ -16,7 +16,7 @@
  *  6. Download throughput measurement:
  *     Start TTC RPU counter, wait for IPI kick, check if data is available,
  *     if yes, read as much data as possible from shared memory. It will
- *     iterates untill 1000 packages have been received, stop TTC RPU counter
+ *     iterates until 1000 packages have been received, stop TTC RPU counter
  *     and kick IPI to notify the remote. Repeat for different package size.
  *  7. Upload throughput measurement:
  *     Start TTC RPU counter, write data to shared memory and kick IPI to
@@ -144,7 +144,7 @@ static int ipi_irq_handler (int vect_id, void *priv)
  *        - Download throughput measurement:
  *          Start TTC RPU counter, wait for IPI kick, check if data is
  *          available, if yes, read as much data as possible from shared
- *          memory. It will iterates untill 1000 packages have been received,
+ *          memory. It will iterates until 1000 packages have been received,
  *          stop TTC RPU counter and kick IPI to notify the remote. Repeat
  *          for different package size.
  *        - Upload throughput measurement:

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/common.h
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/common.h
@@ -35,7 +35,7 @@
 #define IPI_ISR_OFFSET  0x10 /* IPI interrupt status reg offset */
 #define IPI_IMR_OFFSET  0x14 /* IPI interrupt mask reg offset */
 #define IPI_IER_OFFSET  0x18 /* IPI interrupt enable reg offset */
-#define IPI_IDR_OFFSET  0x1C /* IPI interrup disable reg offset */
+#define IPI_IDR_OFFSET  0x1C /* IPI interrupt disable reg offset */
 
 #define IPI_MASK        0x1000000 /* IPI mask for kick from APU.
 				     We use PL0 IPI in this demo. */
@@ -140,7 +140,7 @@ static inline void wait_for_interrupt()
 }
 
 /**
- * @breif wait_for_notified() - Loop until notified bit
+ * @brief wait_for_notified() - Loop until notified bit
  *        in channel is set.
  *
  * @param[in] notified - pointer to the notified variable

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/ipi_latency_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/ipi_latency_demod.c
@@ -7,7 +7,7 @@
 /*****************************************************************************
  * ipi_latency_demod.c
  * This is the remote side of the IPI latency measurement demo.
- * This demo does the follwing steps:
+ * This demo does the following steps:
  *
  *  1. Open the shared memory device.
  *  1. Open the TTC timer device.

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/libmetal_amp_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/libmetal_amp_demod.c
@@ -14,7 +14,7 @@
   * 1.  Initialize the platform hardware such as UART, GIC.
   * 2.  Connect the IPI interrupt.
   * 3.  Register IPI device, shared memory descriptor device and shared memory
-  *     device with libmetal in the intialization.
+  *     device with libmetal in the initialization.
   * 4.  In the main application it does the following,
   *     * open the registered libmetal devices: IPI device, shared memory
   *       descriptor device and shared memory device.

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_latency_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_latency_demod.c
@@ -7,7 +7,7 @@
 /*****************************************************************************
  * shmem_latency_demod.c
  * This is the remote side of the IPI latency measurement demo.
- * This demo does the follwing steps:
+ * This demo does the following steps:
  *
  *  1. Get the shared memory device libmetal I/O region.
  *  1. Get the TTC timer device libemtal I/O region.

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_throughput_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_throughput_demod.c
@@ -16,7 +16,7 @@
  *  6. Download throughput measurement:
  *     Start TTC RPU counter, wait for IPI kick, check if data is available,
  *     if yes, read as much data as possible from shared memory. It will
- *     iterates untill 1000 packages have been received, stop TTC RPU counter
+ *     iterates until 1000 packages have been received, stop TTC RPU counter
  *     and kick IPI to notify the remote. Repeat for different package size.
  *  7. Upload throughput measurement:
  *     Start TTC RPU counter, write data to shared memory and kick IPI to
@@ -144,7 +144,7 @@ static int ipi_irq_handler (int vect_id, void *priv)
  *        - Download throughput measurement:
  *          Start TTC RPU counter, wait for IPI kick, check if data is
  *          available, if yes, read as much data as possible from shared
- *          memory. It will iterates untill 1000 packages have been received,
+ *          memory. It will iterates until 1000 packages have been received,
  *          stop TTC RPU counter and kick IPI to notify the remote. Repeat
  *          for different package size.
  *        - Upload throughput measurement:

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/common.h
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/common.h
@@ -33,7 +33,7 @@
 #define IPI_ISR_OFFSET  0x10 /* IPI interrupt status reg offset */
 #define IPI_IMR_OFFSET  0x14 /* IPI interrupt mask reg offset */
 #define IPI_IER_OFFSET  0x18 /* IPI interrupt enable reg offset */
-#define IPI_IDR_OFFSET  0x1C /* IPI interrup disable reg offset */
+#define IPI_IDR_OFFSET  0x1C /* IPI interrupt disable reg offset */
 
 #define IPI_MASK        0x100 /* IPI mask for kick from RPU. */
 
@@ -146,7 +146,7 @@ int shmem_latency_demo();
 int shmem_throughput_demo();
 
 /**
- * @breif wait_for_notified() - Loop until notified bit in channel is set.
+ * @brief wait_for_notified() - Loop until notified bit in channel is set.
  *
  * @param[in] notified - pointer to the notified variable
  */
@@ -167,7 +167,7 @@ static inline void  wait_for_notified(atomic_int *notified)
 }
 
 /**
- * @breif dump_buffer() - print hex value of each byte in the buffer
+ * @brief dump_buffer() - print hex value of each byte in the buffer
  *
  * @param[in] buf - pointer to the buffer
  * @param[in] len - len of the buffer

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/ipi_latency_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/ipi_latency_demo.c
@@ -7,7 +7,7 @@
 /*****************************************************************************
  * ipi_latency_demo.c
  * This demo measures the IPI latency between the APU and RPU.
- * This demo does the follwing steps:
+ * This demo does the following steps:
  *
  *  1. Get the shared memory device I/O region.
  *  1. Get the TTC timer device I/O region.

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/ipi_shmem_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/ipi_shmem_demo.c
@@ -71,7 +71,7 @@ static atomic_int remote_nkicked; /* is remote kicked, 0 - kicked,
 				       1 - not-kicked */
 
 /**
- * @breif get_timestamp() - Get the timestamp
+ * @brief get_timestamp() - Get the timestamp
  *        IT gets the timestamp and return nanoseconds.
  *
  * @return nano seconds.

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_demo.c
@@ -69,7 +69,7 @@ struct msg_hdr_s {
  *        If messages differ, report error.
  *
  *        Steps:
- *        1. Clear demo control and TX/RX avaiable values
+ *        1. Clear demo control and TX/RX available values
  *
  * @param[in] shm_io - metal i/o region of the shared memory
  * @return - return 0 on success, otherwise return error number indicating

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_throughput_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_throughput_demo.c
@@ -24,7 +24,7 @@
  *  7. Download throughput measurement:
  *     Start TTC APU counter, wait for IPI kick, check if data is available,
  *     if yes, read as much data as possible from shared memory. It will
- *     iterates untill 1000 packages have been received, stop TTC APU counter.
+ *     iterates until 1000 packages have been received, stop TTC APU counter.
  *     Wait for RPU IPI kick so that APU can get the TTC RPU TX counter
  *     value. Kick IPI to notify the remote it has read the TTCi counter.
  *     Repeat for different package size.
@@ -182,7 +182,7 @@ static int ipi_irq_handler (int vect_id, void *priv)
  *        - Download throughput measurement:
  *          Start TTC APU counter, wait for IPI kick, check if data is
  *          available, if yes, read as much data as possible from shared
- *          memory. It will iterates untill 1000 packages have been received,
+ *          memory. It will iterates until 1000 packages have been received,
  *          stop TTC APU counter. Wait for RPU IPI kick so that APU can get
  *          the TTC RPU TX counter value. Kick IPI to notify the remote it
  *          has read the TTCi counter. Repeat for different package size.

--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -17,7 +17,7 @@
 #elif defined(__ICCARM__)
 # include <metal/compiler/iar/compiler.h>
 #elif defined(__CC_ARM)
-# error "MDK-ARM ARMCC compiler requires the GNU extentions to work correctly"
+# error "MDK-ARM ARMCC compiler requires the GNU extensions to work correctly"
 #else
 # error "Missing compiler support"
 #endif

--- a/lib/irq_controller.h
+++ b/lib/irq_controller.h
@@ -69,7 +69,7 @@ struct metal_irq_controller {
 		 	*/
 	int irq_num; /**< Number of IRQs managed by the IRQ controller */
 	void *arg; /**< Argument to pass to interrupt controller function */
-	metal_irq_set_enable irq_set_enable; /**< function to set IRQ eanble */
+	metal_irq_set_enable irq_set_enable; /**< function to set IRQ enable */
 	metal_cntr_irq_register irq_register; /**< function to register IRQ
 						* handler
 						*/

--- a/lib/list.h
+++ b/lib/list.h
@@ -27,7 +27,7 @@ struct metal_list {
 };
 
 /*
- * METAL_INIT_LIST - used for initializing an list elmenet in a static struct
+ * METAL_INIT_LIST - used for initializing an list element in a static struct
  * or global
  */
 #define METAL_INIT_LIST(name) { .next = &name, .prev = &name }

--- a/lib/log.h
+++ b/lib/log.h
@@ -63,7 +63,7 @@ extern enum metal_log_level metal_get_log_level(void);
 
 /**
  * @brief	Default libmetal log handler.  This handler prints libmetal log
- *		mesages to stderr.
+ *		messages to stderr.
  * @param[in]	level	log message level.
  * @param[in]	format	log message format string.
  * @return	0 on success, or -errno on failure.

--- a/lib/processor/aarch64/cpu.h
+++ b/lib/processor/aarch64/cpu.h
@@ -6,7 +6,7 @@
 
 /*
  * @file	cpu.h
- * @brief	CPU specific primatives
+ * @brief	CPU specific primitives
  */
 
 #ifndef __METAL_AARCH64_CPU__H__

--- a/lib/processor/arm/cpu.h
+++ b/lib/processor/arm/cpu.h
@@ -6,7 +6,7 @@
 
 /*
  * @file	cpu.h
- * @brief	CPU specific primatives
+ * @brief	CPU specific primitives
  */
 
 #ifndef __METAL_ARM_CPU__H__

--- a/lib/processor/microblaze/cpu.h
+++ b/lib/processor/microblaze/cpu.h
@@ -6,7 +6,7 @@
 
 /*
  * @file	cpu.h
- * @brief	CPU specific primatives on microblaze platform.
+ * @brief	CPU specific primitives on microblaze platform.
  */
 
 #ifndef __METAL_MICROBLAZE__H__

--- a/lib/processor/x86/cpu.h
+++ b/lib/processor/x86/cpu.h
@@ -6,7 +6,7 @@
 
 /*
  * @file	cpu.h
- * @brief	CPU specific primatives
+ * @brief	CPU specific primitives
  */
 
 #ifndef __METAL_X86_CPU__H__

--- a/lib/processor/x86_64/cpu.h
+++ b/lib/processor/x86_64/cpu.h
@@ -6,7 +6,7 @@
 
 /*
  * @file	cpu.h
- * @brief	CPU specific primatives
+ * @brief	CPU specific primitives
  */
 
 #ifndef __METAL_X86_64_CPU__H__

--- a/lib/processor/xtensa/cpu.h
+++ b/lib/processor/xtensa/cpu.h
@@ -6,7 +6,7 @@
 
 /*
  * @file	cpu.h
- * @brief	CPU specific primatives
+ * @brief	CPU specific primitives
  */
 
 #ifndef __METAL_XTENSA_CPU__H__

--- a/lib/system/freertos/zynqmp_a53/sys.c
+++ b/lib/system/freertos/zynqmp_a53/sys.c
@@ -75,7 +75,7 @@ void *metal_machine_io_mem_map(void *va, metal_phys_addr_t pa,
 	if (!flags)
 		return va;
 
-	/* Ensure alignement on a section boundary */
+	/* Ensure alignment on a section boundary */
 	pa &= ~(ttb_size-1UL);
 
 	/*

--- a/lib/system/generic/zynqmp_a53/sys.c
+++ b/lib/system/generic/zynqmp_a53/sys.c
@@ -75,7 +75,7 @@ void *metal_machine_io_mem_map(void *va, metal_phys_addr_t pa,
 	if (!flags)
 		return va;
 
-	/* Ensure alignement on a section boundary */
+	/* Ensure alignment on a section boundary */
 	pa &= ~(ttb_size-1UL);
 
 	/*

--- a/lib/system/linux/mutex.h
+++ b/lib/system/linux/mutex.h
@@ -31,7 +31,7 @@ typedef struct {
 } metal_mutex_t;
 
 /*
- * METAL_MUTEX_INIT - used for initializing an mutex elmenet in a static struct
+ * METAL_MUTEX_INIT - used for initializing an mutex element in a static struct
  * or global
  */
 #define METAL_MUTEX_INIT(m) { ATOMIC_VAR_INIT(0) }

--- a/lib/system/nuttx/mutex.h
+++ b/lib/system/nuttx/mutex.h
@@ -25,7 +25,7 @@ extern "C" {
 typedef mutex_t metal_mutex_t;
 
 /*
- * METAL_MUTEX_INIT - used for initializing an mutex elmenet in a static struct
+ * METAL_MUTEX_INIT - used for initializing an mutex element in a static struct
  * or global
  */
 #define METAL_MUTEX_INIT(m) MUTEX_INITIALIZER

--- a/lib/system/zephyr/mutex.h
+++ b/lib/system/zephyr/mutex.h
@@ -26,7 +26,7 @@ extern "C" {
 typedef struct k_sem metal_mutex_t;
 
 /*
- * METAL_MUTEX_INIT - used for initializing an mutex elmenet in a static struct
+ * METAL_MUTEX_INIT - used for initializing an mutex element in a static struct
  * or global
  */
 #define METAL_MUTEX_INIT(m) _K_SEM_INITIALIZER(m, 1, 1)

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -1188,7 +1188,7 @@ sub sanitise_line {
 	for ($off = 1; $off < length($line); $off++) {
 		$c = substr($line, $off, 1);
 
-		# Comments we are wacking completly including the begin
+		# Comments we are wacking completely including the begin
 		# and end, all to $;.
 		if ($sanitise_quote eq '' && substr($line, $off, 2) eq '/*') {
 			$sanitise_quote = '*/';
@@ -4413,7 +4413,7 @@ sub process {
 ## 		    $line !~ /^.\s*$Type\s+$Ident(?:\s*=[^,{]*)?\s*,\s*$Type\s*$Ident.*/) {
 ##
 ## 			# Remove any bracketed sections to ensure we do not
-## 			# falsly report the parameters of functions.
+## 			# falsely report the parameters of functions.
 ## 			my $ln = $line;
 ## 			while ($ln =~ s/\([^\(\)]*\)//g) {
 ## 			}
@@ -4904,7 +4904,7 @@ sub process {
 			{
 			}
 
-			# Flatten any obvious string concatentation.
+			# Flatten any obvious string concatenation.
 			while ($dstat =~ s/($String)\s*$Ident/$1/ ||
 			       $dstat =~ s/$Ident\s*($String)/$1/)
 			{

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -244,7 +244,7 @@ class Identity(ComplianceTest):
     """
     name = "Identity"
     # git rev-list and git log don't depend on the current (sub)directory
-    # unless explicited
+    # unless explicit
     path_hint = "<git-top>"
 
     def run(self):

--- a/test/metal-test.c
+++ b/test/metal-test.c
@@ -16,7 +16,7 @@
 static METAL_DECLARE_LIST(test_cases);
 
 /*
- * Not every enviornment has strerror() implemented.
+ * Not every environment has strerror() implemented.
  */
 #ifdef NOT_HAVE_STRERROR
 char metal_weak *strerror(int errnum)

--- a/test/system/freertos/alloc.c
+++ b/test/system/freertos/alloc.c
@@ -28,7 +28,7 @@ static void *alloc_thread(void *arg)
 		/* expecting the implementation to be thread safe */
 		ptr = metal_allocate_memory(256 /*10*i*/);
 		if (!ptr) {
-			metal_log(METAL_LOG_DEBUG, "failed to allocate memmory\n");
+			metal_log(METAL_LOG_DEBUG, "failed to allocate memory\n");
 		        rv = (void *)-ENOMEM;
 			break;
 		}

--- a/test/system/generic/alloc.c
+++ b/test/system/generic/alloc.c
@@ -18,7 +18,7 @@ static int alloc(void)
 
 	ptr = metal_allocate_memory(1000);
 	if (!ptr) {
-		metal_log(METAL_LOG_DEBUG, "failed to allocate memmory\n");
+		metal_log(METAL_LOG_DEBUG, "failed to allocate memory\n");
 		return errno;
 	}
 

--- a/test/system/linux/alloc.c
+++ b/test/system/linux/alloc.c
@@ -18,7 +18,7 @@ static int alloc(void)
 
 	ptr = metal_allocate_memory(1000);
 	if (!ptr) {
-		metal_log(METAL_LOG_DEBUG, "failed to allocate memmory\n");
+		metal_log(METAL_LOG_DEBUG, "failed to allocate memory\n");
 		return errno;
 	}
 

--- a/test/system/linux/threads.c
+++ b/test/system/linux/threads.c
@@ -27,7 +27,7 @@ int metal_run_noblock(int threads, metal_thread_t child,
 	pthread_t *tid_p = (pthread_t *)tids;
 
 	if (!tids) {
-		metal_log(METAL_LOG_ERROR, "invalid arguement, tids is NULL.\n");
+		metal_log(METAL_LOG_ERROR, "invalid argument, tids is NULL.\n");
 		return -EINVAL;
 	}
 

--- a/test/system/zephyr/alloc.c
+++ b/test/system/zephyr/alloc.c
@@ -19,7 +19,7 @@ static int alloc(void)
 
 	ptr = metal_allocate_memory(1000);
 	if (!ptr) {
-		metal_log(METAL_LOG_DEBUG, "failed to allocate memmory\n");
+		metal_log(METAL_LOG_DEBUG, "failed to allocate memory\n");
 		return -errno;
 	}
 


### PR DESCRIPTION
Found via `codespell -q 3 -S ./scripts/spelling.txt`