### PR TITLE
lib: fix compilation error with gcc++

### DIFF
--- a/lib/alloc.h
+++ b/lib/alloc.h
@@ -36,12 +36,12 @@ static inline void *metal_allocate_memory(unsigned int size);
  */
 static inline void metal_free_memory(void *ptr);
 
-#include <metal/system/@PROJECT_SYSTEM@/alloc.h>
-
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include <metal/system/@PROJECT_SYSTEM@/alloc.h>
 
 #endif /* __METAL_ALLOC__H__ */

--- a/lib/condition.h
+++ b/lib/condition.h
@@ -63,12 +63,12 @@ static inline int metal_condition_broadcast(struct metal_condition *cv);
  */
 int metal_condition_wait(struct metal_condition *cv, metal_mutex_t *m);
 
-#include <metal/system/@PROJECT_SYSTEM@/condition.h>
-
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include <metal/system/@PROJECT_SYSTEM@/condition.h>
 
 #endif /* __METAL_CONDITION__H__ */

--- a/lib/dma.h
+++ b/lib/dma.h
@@ -12,6 +12,9 @@
 #ifndef __METAL_DMA__H__
 #define __METAL_DMA__H__
 
+#include <stdint.h>
+#include <metal/sys.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,9 +22,6 @@ extern "C" {
 /** \defgroup dma DMA Interfaces
  *  @{
  */
-
-#include <stdint.h>
-#include <metal/sys.h>
 
 #define METAL_DMA_DEV_R  1 /**< DMA direction, device read */
 #define METAL_DMA_DEV_W  2 /**< DMA direction, device write */

--- a/lib/io.h
+++ b/lib/io.h
@@ -363,12 +363,12 @@ int metal_io_block_write(struct metal_io_region *io, unsigned long offset,
 int metal_io_block_set(struct metal_io_region *io, unsigned long offset,
 		       unsigned char value, int len);
 
-#include <metal/system/@PROJECT_SYSTEM@/io.h>
-
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+#include <metal/system/@PROJECT_SYSTEM@/io.h>
 
 #endif /* __METAL_IO__H__ */

--- a/lib/irq.h
+++ b/lib/irq.h
@@ -12,6 +12,9 @@
 #ifndef __METAL_IRQ__H__
 #define __METAL_IRQ__H__
 
+#include <metal/list.h>
+#include <stdlib.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,9 +22,6 @@ extern "C" {
 /** \defgroup irq Interrupt Handling Interfaces
  *  @{
  */
-
-#include <metal/list.h>
-#include <stdlib.h>
 
 /** IRQ handled status */
 #define METAL_IRQ_NOT_HANDLED 0

--- a/lib/mutex.h
+++ b/lib/mutex.h
@@ -12,6 +12,8 @@
 #ifndef __METAL_MUTEX__H__
 #define __METAL_MUTEX__H__
 
+#include <metal/system/@PROJECT_SYSTEM@/mutex.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,8 +21,6 @@ extern "C" {
 /** \defgroup mutex Mutex Interfaces
  *  @{
  */
-
-#include <metal/system/@PROJECT_SYSTEM@/mutex.h>
 
 /**
  * @brief	Initialize a libmetal mutex.

--- a/lib/softirq.h
+++ b/lib/softirq.h
@@ -12,6 +12,8 @@
 #ifndef __METAL_SOFTIRQ__H__
 #define __METAL_SOFTIRQ__H__
 
+#include <metal/irq.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,8 +21,6 @@ extern "C" {
 /** \defgroup soft irq Interrupt Handling Interfaces
  *  @{
  */
-
-#include <metal/irq.h>
 
 /**
  * @brief	metal_softirq_init

--- a/lib/time.h
+++ b/lib/time.h
@@ -12,6 +12,9 @@
 #ifndef __METAL_TIME__H__
 #define __METAL_TIME__H__
 
+#include <stdint.h>
+#include <metal/sys.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,9 +22,6 @@ extern "C" {
 /** \defgroup time TIME Interfaces
  *  @{
  */
-
-#include <stdint.h>
-#include <metal/sys.h>
 
 /**
  * @brief      get timestamp


### PR DESCRIPTION
The header files including must be outside of the extern "C" { statement.
To be able to be included from C++ code.

Else such error can occur (reproduce on STM32MP1Cube distribution)
gcc/arm-none-eabi/include/c++/10.2.1/atomic:1467:3: error: template with C linkage
 1467 |   template<typename _ITp>
      |   ^~~~~~~~
In file included from STM32CubeMP1/Middlewares/Third_Party/OpenAMP/open-amp/lib/include/openamp/rpmsg.h:16,
                 from STM32CubeMP1/Middlewares/Third_Party/OpenAMP/open-amp/lib/include/openamp/open_amp.h:11,
                 from empty_main.cpp:1:
STM32CubeMP1/Middlewares/Third_Party/OpenAMP/libmetal/lib/include/metal/mutex.h:16:1: note: 'extern "C"' linkage
started here
   16 | extern "C" {
      | ^~~~~~~~~~

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@foss.st.com>