### PR TITLE
CI: Use 'main' branch instead of 'master'.

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -5,7 +5,7 @@ name: libmetal compliance checks
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
       - docs/**
       - cmake/**
@@ -35,7 +35,7 @@ jobs:
         ./scripts/ci/check_compliance.py -m checkpatch  -m Gitlint -m Identity -c origin/${BASE_REF}..
 
     - name: upload-results
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       continue-on-error: True
       with:
         name: compliance.xml

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,13 +5,13 @@ name: libmetal Continuous Integration
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
       - docs/**
       - cmake/**
       - scripts/**
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
       - docs/**
       - cmake/**


### PR DESCRIPTION
See #183 for the underlying issue. 

Signed-off-by: Ed Mooring <ed.mooring@gmail.com>

