### PR TITLE
zephyr: Enable support for RISCV

### DIFF
--- a/cmake/syscheck.cmake
+++ b/cmake/syscheck.cmake
@@ -10,5 +10,8 @@ if (WITH_ZEPHYR)
   if (CONFIG_ARM)
     set (MACHINE "arm" CACHE STRING "")
   endif(CONFIG_ARM)
+  if (CONFIG_RISCV)
+    set (MACHINE "riscv" CACHE STRING "")
+  endif (CONFIG_RISCV)
 
 endif (WITH_ZEPHYR)

--- a/lib/system/zephyr/riscv/CMakeLists.txt
+++ b/lib/system/zephyr/riscv/CMakeLists.txt
@@ -1,0 +1,2 @@
+collect (PROJECT_LIB_HEADERS sys.h)
+collect (PROJECT_LIB_SOURCES sys.c)

--- a/lib/system/zephyr/riscv/sys.c
+++ b/lib/system/zephyr/riscv/sys.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	zephyr/riscv/sys.c
+ * @brief	machine specific system primitives implementation.
+ */
+
+#include <metal/io.h>
+#include <metal/sys.h>
+#include <stdint.h>
+
+/**
+ * @brief poll function until some event happens
+ */
+void metal_weak metal_generic_default_poll(void)
+{
+	metal_asm __volatile__("wfi");
+}

--- a/lib/system/zephyr/riscv/sys.h
+++ b/lib/system/zephyr/riscv/sys.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	zephyr/riscv/sys.h
+ * @brief	Zephyr riscv system primitives for libmetal.
+ */
+
+#ifndef __METAL_ZEPHYR_SYS__H__
+#error "Include metal/sys.h instead of metal/generic/@PROJECT_MACHINE@/sys.h"
+#endif
+
+#ifndef __METAL_ZEPHYR_RISCV_SYS__H__
+#define __METAL_ZEPHYR_RISCV_SYS__H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_ZEPHYR_RISCV_SYS__H__ */


### PR DESCRIPTION
Make libmetal usable also for RISCV targets.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>