### PR TITLE
zephyr: Enable support for Xtensa

### DIFF
--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -74,8 +74,14 @@ build_zephyr(){
     	cd ./zephyr &&
     	source zephyr-env.sh &&
 	cd ../.. &&
-	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_m3 -DWITH_TESTS=on -Bbuild-zephyr &&
-	cd build-zephyr &&
+        echo  "###### Build for qemu_cortex_m3 ######" &&
+        cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_m3 -DWITH_TESTS=on -Bbuild-zephyr-m3 &&
+        cd build-zephyr-m3 &&
+        make VERBOSE=1 &&
+        cd .. &&
+        echo  "###### Build for qemu_xtensa ######" &&
+        cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_xtensa -DWITH_TESTS=on -Bbuild-zephyr-xtensa &&
+        cd build-zephyr-xtensa &&
 	make VERBOSE=1 &&
 	exit 0
 }

--- a/cmake/syscheck.cmake
+++ b/cmake/syscheck.cmake
@@ -13,5 +13,8 @@ if (WITH_ZEPHYR)
   if (CONFIG_RISCV)
     set (MACHINE "riscv" CACHE STRING "")
   endif (CONFIG_RISCV)
+ if (CONFIG_XTENSA)
+    set (MACHINE "xtensa" CACHE STRING "")
+  endif (CONFIG_XTENSA)
 
 endif (WITH_ZEPHYR)

--- a/lib/system/zephyr/xtensa/CMakeLists.txt
+++ b/lib/system/zephyr/xtensa/CMakeLists.txt
@@ -1,0 +1,2 @@
+collect (PROJECT_LIB_HEADERS sys.h)
+collect (PROJECT_LIB_SOURCES sys.c)

--- a/lib/system/zephyr/xtensa/sys.c
+++ b/lib/system/zephyr/xtensa/sys.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 NXP
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	zephyr/xtensa/sys.c
+ * @brief	machine specific system primitives implementation.
+ */
+
+#include <metal/io.h>
+#include <metal/sys.h>
+#include <stdint.h>
+
+/**
+ * @brief poll function until some event happens
+ */
+void metal_weak metal_generic_default_poll(void)
+{
+	metal_asm __volatile__("waiti 0");
+}

--- a/lib/system/zephyr/xtensa/sys.h
+++ b/lib/system/zephyr/xtensa/sys.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 NXP
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	zephyr/xtensa/sys.h
+ * @brief	Zephyr xtensa system primitives for libmetal.
+ */
+
+#ifndef __METAL_ZEPHYR_SYS__H__
+#error "Include metal/sys.h instead of metal/generic/@PROJECT_MACHINE@/sys.h"
+#endif
+
+#ifndef __METAL_ZEPHYR_XTENSA_SYS__H__
+#define __METAL_ZEPHYR_XTENSA_SYS__H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_ZEPHYR_XTENSA_SYS__H__ */


### PR DESCRIPTION
Make libmetal usable also for Xtensa targets.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>