### PR TITLE
lib: system: zephyr: implement __metal_sleep_usec

### DIFF
--- a/lib/system/zephyr/sleep.h
+++ b/lib/system/zephyr/sleep.h
@@ -16,7 +16,7 @@
 #ifndef __METAL_ZEPHYR_SLEEP__H__
 #define __METAL_ZEPHYR_SLEEP__H__
 
-#include <metal/utilities.h>
+#include <kernel.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,8 +24,7 @@ extern "C" {
 
 static inline int __metal_sleep_usec(unsigned int usec)
 {
-	metal_unused(usec);
-	/* Fix me */
+	k_sleep(K_USEC(usec));
 	return 0;
 }
 


### PR DESCRIPTION
The currently missing implementation causes invalid timeouts when sending
remoteproc messages over virtIO. With this change, the specified timeout
of 15 seconds can be achieved. This seems to be the only usage in Zephyr.

Signed-off-by: Matthias Fend <matthias.fend@emfend.at>