### PR TITLE
CI: enable codespell check 

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -22,6 +22,7 @@ jobs:
         pip3 install junitparser==1.6.3 gitlint
     - uses: actions/checkout@v1
     - name: Run Compliance Tests
+      continue-on-error: true
       id: compliance
       env:
         BASE_REF: ${{ github.base_ref }}
@@ -31,7 +32,6 @@ jobs:
         git config --global user.email "you@example.com"
         git config --global user.name "Your Name"
         git rebase origin/${BASE_REF}
-        export
         ./scripts/ci/check_compliance.py -m checkpatch  -m Gitlint -m Identity -c origin/${BASE_REF}..
 
     - name: upload-results
@@ -46,30 +46,18 @@ jobs:
         if [[ ! -s "compliance.xml" ]]; then
           exit 1;
         fi
-        if [ -s checkpatch.txt ]; then
-           errors=$(cat checkpatch.txt)
-           errors="${errors//'%'/'%25'}"
-           errors="${errors//$'\n'/'%0A'}"
-           errors="${errors//$'\r'/'%0D'}"
-           echo "::error file=Checkpatch.txt::$errors"
-           exit=1
-        fi
-        if [ -s Identity.txt ]; then
-           errors=$(cat Identity.txt)
-           errors="${errors//'%'/'%25'}"
-           errors="${errors//$'\n'/'%0A'}"
-           errors="${errors//$'\r'/'%0D'}"
-           echo "::error file=Identity.txt::$errors"
-           exit=1
-        fi
-        if [ -s Gitlint.txt ]; then
-           errors=$(cat Gitlint.txt)
-           errors="${errors//'%'/'%25'}"
-           errors="${errors//$'\n'/'%0A'}"
-           errors="${errors//$'\r'/'%0D'}"
-           echo "::error file=Gitlint.txt::$errors"
-           exit=1
-        fi
-        if [ ${exit} == 1 ]; then
+
+        for file in checkpatch.txt Identity.txt Gitlint.txt; do
+          if [[ -s $file ]]; then
+            errors=$(cat $file)
+            errors="${errors//'%'/'%25'}"
+            errors="${errors//$'\n'/'%0A'}"
+            errors="${errors//$'\r'/'%0D'}"
+            echo "::error file=${file}::$errors"
+            exit=1
+          fi
+        done
+
+        if [ "${exit}" == "1" ]; then
           exit 1;
         fi

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install python dependencies
       run: |
         pip3 install setuptools
-        pip3 install junitparser==1.6.3 gitlint
+        pip3 install junitparser==1.6.3 gitlint codespell
     - uses: actions/checkout@v1
     - name: Run Compliance Tests
       continue-on-error: true

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -194,7 +194,8 @@ class CheckPatch(ComplianceTest):
         diff = subprocess.Popen(('git', 'diff', COMMIT_RANGE),
                                 stdout=subprocess.PIPE)
         try:
-            subprocess.check_output(checkpatch + ' --mailback' + ' --no-tree' + ' -',
+            subprocess.check_output(checkpatch + ' --mailback' + ' --codespell' +
+                                    ' --no-tree' + ' -',
                                     stdin=diff.stdout,
                                     stderr=subprocess.STDOUT,
                                     shell=True, cwd=GIT_TOP)

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -9,9 +9,9 @@ import subprocess
 import re
 import os
 from email.utils import parseaddr
-from junitparser import TestCase, TestSuite, JUnitXml, Skipped, Error, Failure, Attr
 import logging
 import argparse
+from junitparser import TestCase, TestSuite, JUnitXml, Skipped, Error, Failure, Attr
 import tempfile
 import traceback
 from pathlib import Path
@@ -22,10 +22,6 @@ EDIT_TIP = "\n\n*Tip: The bot edits this comment instead of posting a new " \
            "messages.*"
 
 logger = None
-
-
-# This ends up as None when we're not running in a Zephyr tree
-ZEPHYR_BASE = os.environ.get('ZEPHYR_BASE')
 
 
 def git(*args, cwd=None):
@@ -189,8 +185,7 @@ class CheckPatch(ComplianceTest):
     path_hint = "<git-top>"
 
     def run(self):
-        # Default to Zephyr's checkpatch if ZEPHYR_BASE is set
-        checkpatch = os.path.join(ZEPHYR_BASE or GIT_TOP, 'scripts',
+        checkpatch = os.path.join(GIT_TOP, 'scripts',
                                   'checkpatch.pl')
         if not os.path.exists(checkpatch):
             self.skip(checkpatch + " not found")
@@ -199,18 +194,14 @@ class CheckPatch(ComplianceTest):
         diff = subprocess.Popen(('git', 'diff', COMMIT_RANGE),
                                 stdout=subprocess.PIPE)
         try:
-            subprocess.check_output((checkpatch, '--mailback', '--no-tree', '-'),
+            subprocess.check_output(checkpatch + ' --mailback' + ' --no-tree' + ' -',
                                     stdin=diff.stdout,
                                     stderr=subprocess.STDOUT,
                                     shell=True, cwd=GIT_TOP)
 
         except subprocess.CalledProcessError as ex:
             output = ex.output.decode("utf-8")
-            if re.search("[1-9][0-9]* errors,", output):
-                self.add_failure(output)
-            else:
-                # No errors found, but warnings. Show them.
-                self.add_info(output)
+            self.add_failure(output)
 
 
 class GitLint(ComplianceTest):


### PR DESCRIPTION
The checkpatch.pl allows to run codespell on patches to highlight typo error.
Rebase the CI and checkpatch script on recent version and enable "codespell" tool