### PR TITLE
Doc: fix doc generation warnings in system sleep.h files

### DIFF
--- a/lib/system/freertos/sleep.h
+++ b/lib/system/freertos/sleep.h
@@ -31,8 +31,6 @@ static inline int __metal_sleep_usec(unsigned int usec)
 	return 0;
 }
 
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/lib/system/generic/sleep.h
+++ b/lib/system/generic/sleep.h
@@ -29,8 +29,6 @@ static inline int __metal_sleep_usec(unsigned int usec)
 	return 0;
 }
 
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/lib/system/linux/sleep.h
+++ b/lib/system/linux/sleep.h
@@ -27,8 +27,6 @@ static inline int __metal_sleep_usec(unsigned int usec)
 	return usleep(usec);
 }
 
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/lib/system/nuttx/sleep.h
+++ b/lib/system/nuttx/sleep.h
@@ -27,8 +27,6 @@ static inline int __metal_sleep_usec(unsigned int usec)
 	return nxsig_usleep(usec);
 }
 
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/lib/system/zephyr/sleep.h
+++ b/lib/system/zephyr/sleep.h
@@ -28,8 +28,6 @@ static inline int __metal_sleep_usec(unsigned int usec)
 	return 0;
 }
 
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Fix "unbalanced grouping commands" warnings by cleaning up
the end-of-block occurrences, defined without starting tag.
No need to define an API interface block in these files, the
interface is already described in the main sleep.h file.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@foss.st.com>