### PR TITLE
zephyr: update include paths to use <zephyr/...>

### DIFF
--- a/lib/system/zephyr/alloc.h
+++ b/lib/system/zephyr/alloc.h
@@ -16,7 +16,7 @@
 #ifndef __METAL_ZEPHYR_ALLOC__H__
 #define __METAL_ZEPHYR_ALLOC__H__
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <stdlib.h>
 
 #ifdef __cplusplus

--- a/lib/system/zephyr/assert.h
+++ b/lib/system/zephyr/assert.h
@@ -16,7 +16,7 @@
 #ifndef __METAL_ZEPHYR_ASSERT__H__
 #define __METAL_ZEPHYR_ASSERT__H__
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 /**
  * @brief Assertion macro for Zephyr-based applications.

--- a/lib/system/zephyr/assert.h
+++ b/lib/system/zephyr/assert.h
@@ -16,7 +16,7 @@
 #ifndef __METAL_ZEPHYR_ASSERT__H__
 #define __METAL_ZEPHYR_ASSERT__H__
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 /**
  * @brief Assertion macro for Zephyr-based applications.

--- a/lib/system/zephyr/cache.h
+++ b/lib/system/zephyr/cache.h
@@ -16,7 +16,7 @@
 #ifndef __METAL_ZEPHYR_CACHE__H__
 #define __METAL_ZEPHYR_CACHE__H__
 
-#include <cache.h>
+#include <zephyr/cache.h>
 #include <metal/utilities.h>
 
 #ifdef __cplusplus

--- a/lib/system/zephyr/log.c
+++ b/lib/system/zephyr/log.c
@@ -11,7 +11,7 @@
 
 #include <stdarg.h>
 #include <metal/log.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 static const char * const level_strs[] = {
 	"metal: emergency: ",

--- a/lib/system/zephyr/log.c
+++ b/lib/system/zephyr/log.c
@@ -11,7 +11,7 @@
 
 #include <stdarg.h>
 #include <metal/log.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 static const char * const level_strs[] = {
 	"metal: emergency: ",

--- a/lib/system/zephyr/mutex.h
+++ b/lib/system/zephyr/mutex.h
@@ -17,7 +17,7 @@
 #define __METAL_ZEPHYR_MUTEX__H__
 
 #include <metal/atomic.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/system/zephyr/sleep.h
+++ b/lib/system/zephyr/sleep.h
@@ -16,7 +16,7 @@
 #ifndef __METAL_ZEPHYR_SLEEP__H__
 #define __METAL_ZEPHYR_SLEEP__H__
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/system/zephyr/sys.c
+++ b/lib/system/zephyr/sys.c
@@ -12,7 +12,7 @@
 #include <metal/io.h>
 #include <metal/sys.h>
 
-#include <sys/arch_interface.h>
+#include <zephyr/sys/arch_interface.h>
 
 /**
  * @brief poll function until some event happens

--- a/lib/system/zephyr/time.c
+++ b/lib/system/zephyr/time.c
@@ -10,7 +10,7 @@
  */
 
 #include <metal/time.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 unsigned long long metal_get_timestamp(void)
 {

--- a/test/system/zephyr/alloc.c
+++ b/test/system/zephyr/alloc.c
@@ -10,7 +10,7 @@
 #include <metal/errno.h>
 #include <metal/log.h>
 #include <metal/sys.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 #include "metal-test-internal.h"
 
 static int alloc(void)

--- a/test/system/zephyr/main.c
+++ b/test/system/zephyr/main.c
@@ -5,9 +5,9 @@
  */
 
 #include "metal-test-internal.h"
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <metal/log.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Zephyr has prefixed all of its includes with <zephyr/...>. While the old
mode can still be used (CONFIG_LEGACY_INCLUDE_PATH) and is still enabled
by default, it's better to be prepared for its removal in the future.