### PR TITLE
CMake: Remove deprecation warnings

### DIFF
--- a/cmake/platforms/cross-generic-gcc.cmake
+++ b/cmake/platforms/cross-generic-gcc.cmake
@@ -3,8 +3,10 @@ set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER CACHE STRING "")
 set (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY NEVER CACHE STRING "")
 set (CMAKE_FIND_ROOT_PATH_MODE_INCLUDE NEVER CACHE STRING "")
 
-include (CMakeForceCompiler)
-CMAKE_FORCE_C_COMPILER   ("${CROSS_PREFIX}gcc" GNU)
-CMAKE_FORCE_CXX_COMPILER ("${CROSS_PREFIX}g++" GNU)
+set (CMAKE_C_COMPILER   "${CROSS_PREFIX}gcc")
+set (CMAKE_CXX_COMPILER "${CROSS_PREFIX}g++")
+# _exit is in the BSP rather than in libgcc, leaving this out
+# causes errors in try_compile on ARM generic.
+set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 # vim: expandtab:ts=2:sw=2:smartindent


### PR DESCRIPTION
Use CMAKE_C_COMPILER and CMAKE_CXX_COMPILER instead of CMAKE_FORCE_* to
set the cross compilers.

Signed-off-by: Ed Mooring <ed.mooring@gmail.com>