### PR TITLE
New routine to find a node on a list

### DIFF
--- a/lib/list.h
+++ b/lib/list.h
@@ -12,6 +12,7 @@
 #ifndef __METAL_LIST__H__
 #define __METAL_LIST__H__
 
+#include <stdbool.h>
 #include <stdlib.h>
 
 #ifdef __cplusplus
@@ -96,6 +97,18 @@ static inline struct metal_list *metal_list_first(struct metal_list *list)
 	for ((node) = (list)->next;		\
 	     (node) != (list);			\
 	     (node) = (node)->next)
+
+static inline bool metal_list_find_node(struct metal_list *list,
+					struct metal_list *node)
+{
+	struct metal_list *n;
+
+	metal_list_for_each(list, n) {
+		if (n == node)
+			return true;
+	}
+	return false;
+}
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
metal_list_find_node is used to ensure a node is not on a list before adding it
Signed-off-by: Tammy Leino <tammy_leino@mentor.com>