### PR TITLE
examples: use atomic_flag type, __sync functions

### DIFF
--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/ipi_latency_demod.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/ipi_latency_demod.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -44,7 +45,7 @@ struct channel_s {
 	struct metal_io_region *shm_io; /* Shared memory metal i/o region */
 	struct metal_io_region *ttc_io; /* TTC metal i/o region */
 	uint32_t ipi_mask; /* RPU IPI mask */
-	atomic_int remote_nkicked; /* 0 - kicked from remote */
+	atomic_flag remote_nkicked; /* 0 - kicked from remote */
 };
 
 /**
@@ -200,7 +201,8 @@ int ipi_latency_demod()
 	metal_irq_register(ipi_irq, ipi_irq_handler, &ch);
 	metal_irq_enable(ipi_irq);
 	/* initialize remote_nkicked */
-	atomic_init(&ch.remote_nkicked, 1);
+	ch.remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&ch.remote_nkicked);
 	/* Enable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IER_OFFSET, IPI_MASK);
 

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/ipi_shmem_demod.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/ipi_shmem_demod.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -64,7 +65,7 @@ struct msg_hdr_s {
 	uint32_t len;
 };
 
-static atomic_int remote_nkicked; /* is remote kicked, 0 - kicked,
+static atomic_flag remote_nkicked; /* is remote kicked, 0 - kicked,
 				       1 - not-kicked */
 
 static int ipi_irq_handler (int vect_id, void *priv)
@@ -118,8 +119,6 @@ static int ipi_shmem_echod(struct metal_io_region *ipi_io,
 		ret = -ENOMEM;
 		goto out;
 	}
-	/* Clear shared memory */
-	metal_io_block_set(shm_io, 0, 0, metal_io_region_size(shm_io));
 
 	/* Set tx/rx buffer address offset */
 	tx_avail_offset = SHM_DESC_OFFSET_TX + SHM_DESC_AVAIL_OFFSET;
@@ -264,7 +263,8 @@ int ipi_shmem_demod()
 	metal_irq_register(ipi_irq, ipi_irq_handler, ipi_io);
 	metal_irq_enable(ipi_irq);
 	/* initialize remote_nkicked */
-	atomic_init(&remote_nkicked, 1);
+	remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&remote_nkicked);
 	/* Enable IPI interrupt */
 	metal_io_write32(ipi_io, IPI_IER_OFFSET, IPI_MASK);
 

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_atomic_demod.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_atomic_demod.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -27,7 +28,7 @@
 #define ATOMIC_INT_OFFSET 0x0 /* shared memory offset for atomic operation */
 #define ITERATIONS 5000
 
-static atomic_int remote_nkicked; /* is remote kicked, 0 - kicked,
+static atomic_flag remote_nkicked; /* is remote kicked, 0 - kicked,
 				       1 - not-kicked */
 
 static int ipi_irq_handler (int vect_id, void *priv)
@@ -132,7 +133,8 @@ int atomic_shmem_demod()
 	metal_irq_register(ipi_irq, ipi_irq_handler, ipi_io);
 	metal_irq_enable(ipi_irq);
 	/* initialize remote_nkicked */
-	atomic_init(&remote_nkicked, 1);
+	remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&remote_nkicked);
 	/* Enable IPI interrupt */
 	metal_io_write32(ipi_io, IPI_IER_OFFSET, IPI_MASK);
 

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_latency_demod.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_latency_demod.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -50,7 +51,7 @@ struct channel_s {
 	struct metal_io_region *shm_io; /* Shared memory metal i/o region */
 	struct metal_io_region *ttc_io; /* TTC metal i/o region */
 	uint32_t ipi_mask; /* RPU IPI mask */
-	atomic_int remote_nkicked; /* 0 - kicked from remote */
+	atomic_flag remote_nkicked; /* 0 - kicked from remote */
 };
 
 struct msg_hdr_s {
@@ -247,7 +248,8 @@ int shmem_latency_demod()
 	metal_irq_register(ipi_irq, ipi_irq_handler, &ch);
 	metal_irq_enable(ipi_irq);
 	/* initialize remote_nkicked */
-	atomic_init(&ch.remote_nkicked, 1);
+	ch.remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&ch.remote_nkicked);
 	/* Enable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IER_OFFSET, IPI_MASK);
 

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_throughput_demod.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/shmem_throughput_demod.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -67,7 +68,7 @@ struct channel_s {
 	struct metal_io_region *shm_io; /* Shared memory metal i/o region */
 	struct metal_io_region *ttc_io; /* TTC metal i/o region */
 	uint32_t ipi_mask; /* RPU IPI mask */
-	atomic_int remote_nkicked; /* 0 - kicked from remote */
+	atomic_flag remote_nkicked; /* 0 - kicked from remote */
 };
 
 /**
@@ -229,7 +230,8 @@ static int measure_shmem_throughputd(struct channel_s *ch)
 		/* Stop RPU TTC counter */
 		stop_timer(ch->ttc_io, TTC_CNT_RPU_TO_APU);
 		/* Clear remote kicked flag -- 0 is kicked */
-		atomic_init(&ch->remote_nkicked, 1);
+		atomic_flag_clear(&ch->remote_nkicked);
+		atomic_flag_test_and_set(&ch->remote_nkicked);
 		/* Kick IPI to notify RPU TTC counter value is ready */
 		metal_io_write32(ch->ipi_io, IPI_TRIG_OFFSET, ch->ipi_mask);
 	}
@@ -337,7 +339,8 @@ int shmem_throughput_demod()
 	metal_irq_register(ipi_irq, ipi_irq_handler, &ch);
 	metal_irq_enable(ipi_irq);
 	/* initialize remote_nkicked */
-	atomic_init(&ch.remote_nkicked, 1);
+	ch.remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&ch.remote_nkicked);
 	/* Enable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IER_OFFSET, IPI_MASK);
 

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/common.h
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/common.h
@@ -1,5 +1,6 @@
  /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -145,7 +146,7 @@ static inline void wait_for_interrupt()
  *
  * @param[in] notified - pointer to the notified variable
  */
-static inline void  wait_for_notified(atomic_int *notified)
+static inline void  wait_for_notified(atomic_flag *notified)
 {
 	unsigned int flags;
 

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/ipi_latency_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/ipi_latency_demod.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -44,7 +45,7 @@ struct channel_s {
 	struct metal_io_region *shm_io; /* Shared memory metal i/o region */
 	struct metal_io_region *ttc_io; /* TTC metal i/o region */
 	uint32_t ipi_mask; /* RPU IPI mask */
-	atomic_int remote_nkicked; /* 0 - kicked from remote */
+	atomic_flag remote_nkicked; /* 0 - kicked from remote */
 };
 
 /**
@@ -200,7 +201,8 @@ int ipi_latency_demod()
 	metal_irq_register(ipi_irq, ipi_irq_handler, &ch);
 	metal_irq_enable(ipi_irq);
 	/* initialize remote_nkicked */
-	atomic_init(&ch.remote_nkicked, 1);
+	ch.remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&ch.remote_nkicked);
 	/* Enable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IER_OFFSET, IPI_MASK);
 

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/ipi_shmem_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/ipi_shmem_demod.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -64,7 +65,7 @@ struct msg_hdr_s {
 	uint32_t len;
 };
 
-static atomic_int remote_nkicked; /* is remote kicked, 0 - kicked,
+static atomic_flag remote_nkicked; /* is remote kicked, 0 - kicked,
 				       1 - not-kicked */
 
 static int ipi_irq_handler (int vect_id, void *priv)
@@ -118,8 +119,6 @@ static int ipi_shmem_echod(struct metal_io_region *ipi_io,
 		ret = -ENOMEM;
 		goto out;
 	}
-	/* Clear shared memory */
-	metal_io_block_set(shm_io, 0, 0, metal_io_region_size(shm_io));
 
 	/* Set tx/rx buffer address offset */
 	tx_avail_offset = SHM_DESC_OFFSET_TX + SHM_DESC_AVAIL_OFFSET;
@@ -264,7 +263,8 @@ int ipi_shmem_demod()
 	metal_irq_register(ipi_irq, ipi_irq_handler, ipi_io);
 	metal_irq_enable(ipi_irq);
 	/* initialize remote_nkicked */
-	atomic_init(&remote_nkicked, 1);
+	remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&remote_nkicked);
 	/* Enable IPI interrupt */
 	metal_io_write32(ipi_io, IPI_IER_OFFSET, IPI_MASK);
 

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_atomic_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_atomic_demod.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -27,7 +28,7 @@
 #define ATOMIC_INT_OFFSET 0x0 /* shared memory offset for atomic operation */
 #define ITERATIONS 5000
 
-static atomic_int remote_nkicked; /* is remote kicked, 0 - kicked,
+static atomic_flag remote_nkicked; /* is remote kicked, 0 - kicked,
 				       1 - not-kicked */
 
 static int ipi_irq_handler (int vect_id, void *priv)
@@ -132,7 +133,8 @@ int atomic_shmem_demod()
 	metal_irq_register(ipi_irq, ipi_irq_handler, ipi_io);
 	metal_irq_enable(ipi_irq);
 	/* initialize remote_nkicked */
-	atomic_init(&remote_nkicked, 1);
+	remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&remote_nkicked);
 	/* Enable IPI interrupt */
 	metal_io_write32(ipi_io, IPI_IER_OFFSET, IPI_MASK);
 

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_latency_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_latency_demod.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -50,7 +51,7 @@ struct channel_s {
 	struct metal_io_region *shm_io; /* Shared memory metal i/o region */
 	struct metal_io_region *ttc_io; /* TTC metal i/o region */
 	uint32_t ipi_mask; /* RPU IPI mask */
-	atomic_int remote_nkicked; /* 0 - kicked from remote */
+	atomic_flag remote_nkicked; /* 0 - kicked from remote */
 };
 
 struct msg_hdr_s {
@@ -247,7 +248,8 @@ int shmem_latency_demod()
 	metal_irq_register(ipi_irq, ipi_irq_handler, &ch);
 	metal_irq_enable(ipi_irq);
 	/* initialize remote_nkicked */
-	atomic_init(&ch.remote_nkicked, 1);
+	ch.remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&ch.remote_nkicked);
 	/* Enable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IER_OFFSET, IPI_MASK);
 

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_throughput_demod.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/shmem_throughput_demod.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -67,7 +68,7 @@ struct channel_s {
 	struct metal_io_region *shm_io; /* Shared memory metal i/o region */
 	struct metal_io_region *ttc_io; /* TTC metal i/o region */
 	uint32_t ipi_mask; /* RPU IPI mask */
-	atomic_int remote_nkicked; /* 0 - kicked from remote */
+	atomic_flag remote_nkicked; /* 0 - kicked from remote */
 };
 
 /**
@@ -229,7 +230,8 @@ static int measure_shmem_throughputd(struct channel_s *ch)
 		/* Stop RPU TTC counter */
 		stop_timer(ch->ttc_io, TTC_CNT_RPU_TO_APU);
 		/* Clear remote kicked flag -- 0 is kicked */
-		atomic_init(&ch->remote_nkicked, 1);
+		atomic_flag_clear(&ch->remote_nkicked);
+		atomic_flag_test_and_set(&ch->remote_nkicked);
 		/* Kick IPI to notify RPU TTC counter value is ready */
 		metal_io_write32(ch->ipi_io, IPI_TRIG_OFFSET, ch->ipi_mask);
 	}
@@ -337,7 +339,8 @@ int shmem_throughput_demod()
 	metal_irq_register(ipi_irq, ipi_irq_handler, &ch);
 	metal_irq_enable(ipi_irq);
 	/* initialize remote_nkicked */
-	atomic_init(&ch.remote_nkicked, 1);
+	ch.remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&ch.remote_nkicked);
 	/* Enable IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_IER_OFFSET, IPI_MASK);
 

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/common.h
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/common.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -150,7 +151,7 @@ int shmem_throughput_demo();
  *
  * @param[in] notified - pointer to the notified variable
  */
-static inline void  wait_for_notified(atomic_int *notified)
+static inline void  wait_for_notified(atomic_flag *notified)
 {
 	unsigned int flags;
 

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/ipi_latency_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/ipi_latency_demo.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -57,7 +58,7 @@ struct channel_s {
 	struct metal_device *ttc_dev; /* TTC metal device */
 	struct metal_io_region *ttc_io; /* TTC metal i/o region */
 	uint32_t ipi_mask; /* RPU IPI mask */
-	atomic_int remote_nkicked; /* 0 - kicked from remote */
+	atomic_flag remote_nkicked; /* 0 - kicked from remote */
 };
 
 /**
@@ -267,7 +268,8 @@ int ipi_latency_demo()
 	/* clear old IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_ISR_OFFSET, IPI_MASK);
 	/* initialize remote_nkicked */
-	atomic_init(&ch.remote_nkicked, 1);
+	ch.remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&ch.remote_nkicked);
 	ch.ipi_mask = IPI_MASK;
 	/* Register IPI irq handler */
 	metal_irq_register(ipi_irq, ipi_irq_handler, &ch);

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/ipi_shmem_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/ipi_shmem_demo.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -67,7 +68,7 @@ struct msg_hdr_s {
 	uint32_t len;
 };
 
-static atomic_int remote_nkicked; /* is remote kicked, 0 - kicked,
+static atomic_flag remote_nkicked; /* is remote kicked, 0 - kicked,
 				       1 - not-kicked */
 
 /**
@@ -369,7 +370,8 @@ int ipi_shmem_demo()
 	metal_irq_register(ipi_irq, ipi_irq_handler, ipi_io);
 	metal_irq_enable(ipi_irq);
 	/* initialize remote_nkicked */
-	atomic_init(&remote_nkicked, 1);
+	remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&remote_nkicked);
 	/* Enable IPI interrupt */
 	metal_io_write32(ipi_io, IPI_IER_OFFSET, IPI_MASK);
 

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_atomic_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_atomic_demo.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -35,7 +36,7 @@
 #define ATOMIC_INT_OFFSET 0x0 /* shared memory offset for atomic operation */
 #define ITERATIONS 5000
 
-static atomic_int remote_nkicked; /* is remote kicked, 0 - kicked,
+static atomic_flag remote_nkicked; /* is remote kicked, 0 - kicked,
 				       1 - not-kicked */
 
 static int ipi_irq_handler (int vect_id, void *priv)
@@ -160,7 +161,8 @@ int atomic_shmem_demo()
 	metal_irq_register(ipi_irq, ipi_irq_handler, ipi_io);
 	metal_irq_enable(ipi_irq);
 	/* initialize remote_nkicked */
-	atomic_init(&remote_nkicked, 1);
+	remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&remote_nkicked);
 	/* Enable IPI interrupt */
 	metal_io_write32(ipi_io, IPI_IER_OFFSET, IPI_MASK);
 

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_latency_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_latency_demo.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -64,7 +65,7 @@ struct channel_s {
 	struct metal_device *ttc_dev; /* TTC metal device */
 	struct metal_io_region *ttc_io; /* TTC metal i/o region */
 	uint32_t ipi_mask; /* RPU IPI mask */
-	atomic_int remote_nkicked; /* 0 - kicked from remote */
+	atomic_flag remote_nkicked; /* 0 - kicked from remote */
 };
 
 struct msg_hdr_s {
@@ -325,7 +326,8 @@ int shmem_latency_demo()
 	/* clear old IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_ISR_OFFSET, IPI_MASK);
 	/* initialize remote_nkicked */
-	atomic_init(&ch.remote_nkicked, 1);
+	ch.remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&ch.remote_nkicked);
 	ch.ipi_mask = IPI_MASK;
 	/* Register IPI irq handler */
 	metal_irq_register(ipi_irq, ipi_irq_handler, &ch);

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_throughput_demo.c
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/shmem_throughput_demo.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (C) 2022, Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -82,7 +83,7 @@ struct channel_s {
 	struct metal_device *ttc_dev; /* TTC metal device */
 	struct metal_io_region *ttc_io; /* TTC metal i/o region */
 	uint32_t ipi_mask; /* RPU IPI mask */
-	atomic_int remote_nkicked; /* 0 - kicked from remote */
+	atomic_flag remote_nkicked; /* 0 - kicked from remote */
 };
 
 /**
@@ -328,7 +329,8 @@ static int measure_shmem_throughput(struct channel_s* ch)
 		/* Stop RPU TTC counter */
 		stop_timer(ch->ttc_io, TTC_CNT_APU_TO_RPU);
 		/* Clear remote kicked flag -- 0 is kicked */
-		atomic_init(&ch->remote_nkicked, 1);
+		atomic_flag_clear(&ch->remote_nkicked);
+		atomic_flag_test_and_set(&ch->remote_nkicked);
 		/* Kick IPI to notify remote it is ready to read data */
 		metal_io_write32(ch->ipi_io, IPI_TRIG_OFFSET, ch->ipi_mask);
 		/* Wait for RPU to signal RPU TX TTC counter is ready to
@@ -441,7 +443,8 @@ int shmem_throughput_demo()
 	/* clear old IPI interrupt */
 	metal_io_write32(ch.ipi_io, IPI_ISR_OFFSET, IPI_MASK);
 	/* initialize remote_nkicked */
-	atomic_init(&ch.remote_nkicked, 1);
+	ch.remote_nkicked = (atomic_flag)ATOMIC_FLAG_INIT;
+	atomic_flag_test_and_set(&ch.remote_nkicked);
 	ch.ipi_mask = IPI_MASK;
 	/* Register IPI irq handler */
 	metal_irq_register(ipi_irq, ipi_irq_handler, &ch);


### PR DESCRIPTION
Use atomic_flag type and the GCC __sync built-in
functions for atomic memory access.

Signed-off-by: Sergei Korneichuk <sergei.korneichuk@amd.com>