### PR TITLE
Update LICENSE.md to cover CI test scripts

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -29,12 +29,53 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
+Apache License :2.0
+========================================
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+GPL 2.0
+========================================
+
+Copyright (C) yyyy  name of author
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+Linux Syscall Note
+========================================
+
+NOTE! This copyright does *not* cover user programs that use kernel services by normal system calls - this is merely considered normal use of the kernel, and does *not* fall under the heading of "derived work". Also note that the GPL below is copyrighted by the Free Software Foundation, but the instance of code that it refers to (the Linux kernel) is copyrighted by me and others who actually wrote it.
+
+Also note that the only valid version of the GPL as far as the kernel is concerned is _this_ particular version of the license (ie v2, not v2.2 or v3.x or whatever), unless explicitly otherwise stated.
 
 Notes
 =========================================
 Use the following tag instead of the full license text in the individual files:
 
     SPDX-License-Identifier:    BSD-3-Clause
+    SPDX-License-Identifier:    Apache-2.0
+    SPDX-License-Identifier:    GPL-2.0
+    SPDX-License-Identifier:    GPL-2.0 WITH Linux-syscall-note
 
 This enables machine processing of license information based on the SPDX
 License Identifiers that are here available: http://spdx.org/licenses/


### PR DESCRIPTION
Update LICENSE.md with full and SPDX identifier details.
Note: Neither Apache nor GPL are used by the libmetal library itself.

Signed-off-by: Manikanta Sreeram <manikanta.sreeram@xilinx.com>