### PR TITLE
cmake: use set_property for PROJECT_EC_FLAGS

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -72,5 +72,5 @@ option (WITH_DEFAULT_LOGGER "Build with default logger" ON)
 
 option (WITH_DOC "Build with documentation" ON)
 
-set (GLOBAL PROPERTY "PROJECT_EC_FLAGS" "-Wall -Werror -Wextra" CACHE STRING "")
+set_property (GLOBAL PROPERTY "PROJECT_EC_FLAGS" -Wall -Werror -Wextra)
 # vim: expandtab:ts=2:sw=2:smartindent


### PR DESCRIPTION
Fix PROJECT_EC_FLAGS definition: use set_property instead of set.

Signed-off-by: Sergei Korneichuk <sergei.korneichuk@amd.com>

--
This PR fixes an error in [cmake: set PROJECT_EC_FLAGS to be GLOBAL property](https://github.com/OpenAMP/libmetal/commit/d077e286a43784e517477e65071f1be15308f504)