### PR TITLE
lib: system: freertos: remove deprecated METAL_MUTEX_INIT

### DIFF
--- a/lib/system/freertos/mutex.h
+++ b/lib/system/freertos/mutex.h
@@ -30,21 +30,6 @@ typedef struct {
 } metal_mutex_t;
 
 /*
- * METAL_MUTEX_INIT - used for initializing an mutex element in a static struct
- * or global
- */
-#if defined(__GNUC__)
-#define METAL_MUTEX_INIT(m) { NULL }; \
-_Pragma("GCC warning\"static initialisation of the mutex is deprecated\"")
-#elif defined(__ICCARM__)
-#define DO_PRAGMA(x) _Pragma(#x)
-#define METAL_MUTEX_INIT(m) { NULL }; \
-DO_PRAGMA(message("Warning: static initialisation of the mutex is deprecated"))
-#else
-#define METAL_MUTEX_INIT(m) { NULL }
-#endif
-
-/*
  * METAL_MUTEX_DEFINE - used for defining and initializing a global or
  * static singleton mutex
  */


### PR DESCRIPTION
The `METAL_MUTEX_INIT` macro has been deprecated in release 2021.04.0
Remove it after it has been in a depreciated state for 2 years.