### PR TITLE
CI: fix zephyr cmake error "No prj.conf file was found"

### DIFF
--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -78,6 +78,8 @@ build_zephyr(){
     	cd ./zephyr &&
     	source zephyr-env.sh &&
 	cd ../.. &&
+	# The prj.conf is mandatory for cmake execution, create a void file.
+	touch prj.conf &&
         echo  "###### Build for qemu_cortex_m3 ######" &&
         cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_m3 -DWITH_TESTS=on -Bbuild-zephyr-m3 &&
         cd build-zephyr-m3 &&


### PR DESCRIPTION
Zephyr build requests to have a prj.conf file for build. Create an empty one.