### PR TITLE
Wrap vars ifndef

### DIFF
--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/common.h
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/common.h
@@ -36,8 +36,12 @@
 #define IPI_IER_OFFSET  0x18 /* IPI interrupt enable reg offset */
 #define IPI_IDR_OFFSET  0x1C /* IPI interrupt disable reg offset */
 
-#define IPI_MASK        0x1000000 /* IPI mask for kick from APU.
-				     We use PL0 IPI in this demo. */
+#ifndef IPI_MASK
+/*
+ * IPI mask for kick from APU. We use PL0 IPI in this demo.
+ */
+#define IPI_MASK        0x1000000
+#endif
 
 /* TTC counter offsets */
 #define XTTCPS_CLK_CNTRL_OFFSET 0x0  /* TTC counter clock control reg offset */

--- a/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/sys_init.c
+++ b/examples/system/freertos/zynqmp_r5/zynqmp_amp_demo/sys_init.c
@@ -29,11 +29,21 @@
 
 #define INTC_DEVICE_ID		XPAR_SCUGIC_0_DEVICE_ID
 
+#ifndef IPI_IRQ_VECT_ID
 #define IPI_IRQ_VECT_ID         65
+#endif
 
+#ifndef SHM_BASE_ADDR
 #define SHM_BASE_ADDR   0x3ED80000
+#endif
+
+#ifndef TTC0_BASE_ADDR
 #define TTC0_BASE_ADDR  0xFF110000
+#endif
+
+#ifndef IPI_BASE_ADDR
 #define IPI_BASE_ADDR   0xFF310000
+#endif
 
 /* Default generic I/O region page shift */
 /* Each I/O region can contain multiple pages.

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/common.h
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/common.h
@@ -26,9 +26,18 @@
 
 /* Devices names */
 #define BUS_NAME        "generic"
+
+#ifndef IPI_DEV_NAME
 #define IPI_DEV_NAME    "ff310000.ipi"
+#endif
+
+#ifndef SHM_DEV_NAME
 #define SHM_DEV_NAME    "3ed80000.shm"
+#endif
+
+#ifndef TTC_DEV_NAME
 #define TTC_DEV_NAME    "ff110000.ttc"
+#endif
 
 /* IPI registers offset */
 #define IPI_TRIG_OFFSET 0x0  /* IPI trigger reg offset */
@@ -38,8 +47,12 @@
 #define IPI_IER_OFFSET  0x18 /* IPI interrupt enable reg offset */
 #define IPI_IDR_OFFSET  0x1C /* IPI interrupt disable reg offset */
 
-#define IPI_MASK        0x1000000 /* IPI mask for kick from APU.
-				     We use PL0 IPI in this demo. */
+#ifndef IPI_MASK
+/*
+ * IPI mask for kick from APU. We use PL0 IPI in this demo.
+ */
+#define IPI_MASK        0x1000000
+#endif
 
 /* TTC counter offsets */
 #define XTTCPS_CLK_CNTRL_OFFSET 0x0  /* TTC counter clock control reg offset */

--- a/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/sys_init.c
+++ b/examples/system/generic/zynqmp_r5/zynqmp_amp_demo/sys_init.c
@@ -29,11 +29,21 @@
 
 #define INTC_DEVICE_ID		XPAR_SCUGIC_0_DEVICE_ID
 
+#ifndef IPI_IRQ_VECT_ID
 #define IPI_IRQ_VECT_ID         65
+#endif
 
+#ifndef SHM_BASE_ADDR
 #define SHM_BASE_ADDR   0x3ED80000
+#endif
+
+#ifndef TTC0_BASE_ADDR
 #define TTC0_BASE_ADDR  0xFF110000
+#endif
+
+#ifndef IPI_BASE_ADDR
 #define IPI_BASE_ADDR   0xFF310000
+#endif
 
 /* Default generic I/O region page shift */
 /* Each I/O region can contain multiple pages.

--- a/examples/system/linux/zynqmp/zynqmp_amp_demo/common.h
+++ b/examples/system/linux/zynqmp/zynqmp_amp_demo/common.h
@@ -15,9 +15,18 @@
 #include <stdio.h>
 
 #define BUS_NAME        "platform"
+
+#ifndef IPI_DEV_NAME
 #define IPI_DEV_NAME    "ff340000.ipi"
+#endif
+
+#ifndef SHM_DEV_NAME
 #define SHM_DEV_NAME    "3ed80000.shm"
+#endif
+
+#ifndef TTC_DEV_NAME
 #define TTC_DEV_NAME    "ff110000.timer"
+#endif
 
 /* Apply this snippet to the device tree in an overlay so that
  * Linux userspace can see and use TTC0:
@@ -36,7 +45,9 @@
 #define IPI_IER_OFFSET  0x18 /* IPI interrupt enable reg offset */
 #define IPI_IDR_OFFSET  0x1C /* IPI interrupt disable reg offset */
 
+#ifndef IPI_MASK
 #define IPI_MASK        0x100 /* IPI mask for kick from RPU. */
+#endif
 
 /* TTC counter offsets */
 #define XTTCPS_CLK_CNTRL_OFFSET 0x0  /* TTC counter clock control reg offset */


### PR DESCRIPTION
Enable demos to be configured via CMake configure or toolchain file.

This enables the demos to be configured for Versal and Versal_Net platforms.

