### PR TITLE
lib: remove MB and GB definition in utilities.h

### DIFF
--- a/lib/system/generic/xlnx_common/zynqmp_aarch64/sys.c
+++ b/lib/system/generic/xlnx_common/zynqmp_aarch64/sys.c
@@ -27,6 +27,14 @@
 #include "xreg_cortexa53.h"
 #endif /* defined(versal) */
 
+#ifndef MB
+#define MB (1024 * 1024UL)
+#endif /* MB */
+
+#ifndef GB
+#define GB (MB * 1024UL)
+#endif /* GB */
+
 void sys_irq_restore_enable(unsigned int flags)
 {
 	Xil_ExceptionEnableMask(~flags);

--- a/lib/utilities.h
+++ b/lib/utilities.h
@@ -25,9 +25,6 @@ extern "C" {
  *  @{
  */
 
-#define MB (1024 * 1024UL)
-#define GB (1024 * 1024 * 1024UL)
-
 /** Marker for unused function arguments/variables. */
 #define metal_unused(x)	do { (x) = (x); } while (0)
 


### PR DESCRIPTION
The introduction of MB and GB macros introduces warnings in Zephyr build.
Indeed they are already defined in zephyr/include/zephyr/sys/util.h. Remove them and put them back in
lib/system/generic/xlnx_common/zynqmp_aarch64/sys.c.