### PR TITLE
lib: refactor alloc.h to not need forward declaration

### DIFF
--- a/lib/alloc.h
+++ b/lib/alloc.h
@@ -12,6 +12,8 @@
 #ifndef __METAL_ALLOC__H__
 #define __METAL_ALLOC__H__
 
+#include <metal/system/@PROJECT_SYSTEM@/alloc.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -27,21 +29,25 @@ extern "C" {
  * @param[in]  size        size in byte of requested memory
  * @return     memory pointer, or 0 if it failed to allocate
  */
-static inline void *metal_allocate_memory(unsigned int size);
+static inline void *metal_allocate_memory(unsigned int size)
+{
+	return __metal_allocate_memory(size);
+}
 
 /**
  * @brief      free the memory previously allocated
  *
  * @param[in]  ptr       pointer to memory
  */
-static inline void metal_free_memory(void *ptr);
+static inline void metal_free_memory(void *ptr)
+{
+	__metal_free_memory(ptr);
+}
 
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
-
-#include <metal/system/@PROJECT_SYSTEM@/alloc.h>
 
 #endif /* __METAL_ALLOC__H__ */

--- a/lib/system/freertos/alloc.h
+++ b/lib/system/freertos/alloc.h
@@ -22,12 +22,12 @@
 extern "C" {
 #endif
 
-static inline void *metal_allocate_memory(unsigned int size)
+static inline void *__metal_allocate_memory(unsigned int size)
 {
 	return pvPortMalloc(size);
 }
 
-static inline void metal_free_memory(void *ptr)
+static inline void __metal_free_memory(void *ptr)
 {
 	vPortFree(ptr);
 }

--- a/lib/system/generic/alloc.h
+++ b/lib/system/generic/alloc.h
@@ -22,12 +22,12 @@
 extern "C" {
 #endif
 
-static inline void *metal_allocate_memory(unsigned int size)
+static inline void *__metal_allocate_memory(unsigned int size)
 {
 	return malloc(size);
 }
 
-static inline void metal_free_memory(void *ptr)
+static inline void __metal_free_memory(void *ptr)
 {
 	free(ptr);
 }

--- a/lib/system/linux/alloc.h
+++ b/lib/system/linux/alloc.h
@@ -22,12 +22,12 @@
 extern "C" {
 #endif
 
-static inline void *metal_allocate_memory(unsigned int size)
+static inline void *__metal_allocate_memory(unsigned int size)
 {
 	return malloc(size);
 }
 
-static inline void metal_free_memory(void *ptr)
+static inline void __metal_free_memory(void *ptr)
 {
 	free(ptr);
 }

--- a/lib/system/nuttx/alloc.h
+++ b/lib/system/nuttx/alloc.h
@@ -22,12 +22,12 @@
 extern "C" {
 #endif
 
-static inline void *metal_allocate_memory(unsigned int size)
+static inline void *__metal_allocate_memory(unsigned int size)
 {
 	return kmm_malloc(size);
 }
 
-static inline void metal_free_memory(void *ptr)
+static inline void __metal_free_memory(void *ptr)
 {
 	kmm_free(ptr);
 }

--- a/lib/system/zephyr/alloc.h
+++ b/lib/system/zephyr/alloc.h
@@ -24,12 +24,12 @@ extern "C" {
 #endif
 
 #if (CONFIG_HEAP_MEM_POOL_SIZE > 0)
-static inline void *metal_allocate_memory(unsigned int size)
+static inline void *__metal_allocate_memory(unsigned int size)
 {
 	return k_malloc(size);
 }
 
-static inline void metal_free_memory(void *ptr)
+static inline void __metal_free_memory(void *ptr)
 {
 	k_free(ptr);
 }
@@ -38,12 +38,12 @@ static inline void metal_free_memory(void *ptr)
 void *metal_zephyr_allocate_memory(unsigned int size);
 void metal_zephyr_free_memory(void *ptr);
 
-static inline void *metal_allocate_memory(unsigned int size)
+static inline void *__metal_allocate_memory(unsigned int size)
 {
 	return metal_zephyr_allocate_memory(size);
 }
 
-static inline void metal_free_memory(void *ptr)
+static inline void __metal_free_memory(void *ptr)
 {
 	metal_zephyr_free_memory(ptr);
 }


### PR DESCRIPTION
This should have no functional change, but makes this header consistent with how the other headers are organized.