### PR TITLE
Export each of the memory_order enumerators

### DIFF
--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -26,6 +26,12 @@
 # include <atomic>
 using std::atomic_flag;
 using std::memory_order;
+using std::memory_order_relaxed;
+using std::memory_order_consume;
+using std::memory_order_acquire;
+using std::memory_order_release;
+using std::memory_order_acq_rel;
+using std::memory_order_seq_cst;
 
 using std::atomic_bool;
 using std::atomic_char;


### PR DESCRIPTION
The lib/atomic.h exports memory_order enum into the global namespace, but none of its enumerators. According to Section 7.3.3 "The using declaration" of the C++ standard: "specifying an enumeration name in a using-declaration does not declare its enumerators in the using-declaration's declarative region." See also: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0943r1.html