### PR TITLE
lib: system: freertos: Add metal/errno.h to match standalone

### DIFF
--- a/lib/system/freertos/sys.h
+++ b/lib/system/freertos/sys.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016, Xilinx Inc. and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All Rights Reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -15,6 +16,8 @@
 
 #ifndef __METAL_FREERTOS_SYS__H__
 #define __METAL_FREERTOS_SYS__H__
+
+#include <metal/errno.h>
 
 #include "./@PROJECT_MACHINE@/sys.h"
 


### PR DESCRIPTION
As lib/system/generic/sys.h has metal/errno.h add this to the freertos equivalent.

This fixes some compilation issues when linking against certain FreeRTOS port BSPs.