### PR TITLE
lib: utilities: add MB and GB defines

### DIFF
--- a/lib/utilities.h
+++ b/lib/utilities.h
@@ -25,8 +25,13 @@ extern "C" {
  *  @{
  */
 
-#define MB (1024 * 1024UL)
-#define GB (1024 * 1024 * 1024UL)
+#ifndef MB
+#define MB (1024UL << 10UL)
+#endif
+
+#ifndef GB
+#define GB (MB << 10UL)
+#endif
 
 /** Marker for unused function arguments/variables. */
 #define metal_unused(x)	do { (x) = (x); } while (0)


### PR DESCRIPTION
If MB and GB definition is not available then define new ones.

This also addresses: https://github.com/OpenAMP/libmetal/pull/242
