### PR TITLE
log: add function name, line number prefix

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -69,6 +69,7 @@ if (WITH_ZEPHYR)
 endif (WITH_ZEPHYR)
 
 option (WITH_DEFAULT_LOGGER "Build with default logger" ON)
+option (WITH_FUNC_LINE_LOG "Log with function name, line number prefix" OFF)
 
 option (WITH_DOC "Build with documentation" ON)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -65,6 +65,10 @@ if (WITH_DEFAULT_LOGGER)
   add_definitions (-DDEFAULT_LOGGER_ON)
 endif (WITH_DEFAULT_LOGGER)
 
+if (WITH_FUNC_LINE_LOG)
+  add_definitions (-DML_FUNC_LINE)
+endif (WITH_FUNC_LINE_LOG)
+
 get_property (_ec_flgs GLOBAL PROPERTY "PROJECT_EC_FLAGS")
 
 if (WITH_ZEPHYR)

--- a/lib/log.h
+++ b/lib/log.h
@@ -72,15 +72,38 @@ extern void metal_default_log_handler(enum metal_log_level level,
 				      const char *format, ...);
 
 /**
- * Emit a log message if the log level permits.
+ * @internal
+ *
+ * @brief	used by the metal_log() macro to update the format string
+ *
+ * If ML_FUNC_LINE is defined this macro generates a unified format
+ * string for metal_log() and its convenience metal_*() macros, i.e. it
+ * adds function-name:line-number prefix to all log messages.
+ *
+ * @param[in]	fmt	format string passed from the metal_log() macro
+ */
+#if defined(ML_FUNC_LINE)
+#define metal_fmt(fmt) "%s:%u " fmt, __func__, __LINE__
+#else	/* ML_FUNC_LINE */
+#define metal_fmt(fmt) fmt
+#endif	/* ML_FUNC_LINE */
+
+/**
+ * @brief	Emit a log message if the log level permits.
  *
  * @param	level	Log level.
- * @param	...	Format string and arguments.
+ * @param	fmt	Format string.
+ * @param	args... Variable number of arguments.
  */
-#define metal_log(level, ...)						       \
-	((level <= _metal.common.log_level && _metal.common.log_handler) \
-	       ? (void)_metal.common.log_handler(level, __VA_ARGS__)	       \
-	       : (void)0)
+#define metal_log(level, fmt, args...) ({				   \
+	if (_metal.common.log_handler && level <= _metal.common.log_level) \
+		_metal.common.log_handler(level, metal_fmt(fmt), ##args);  \
+})
+
+#define metal_err(fmt, args...) metal_log(METAL_LOG_ERROR, fmt, ##args)
+#define metal_warn(fmt, args...) metal_log(METAL_LOG_WARNING, fmt, ##args)
+#define metal_info(fmt, args...) metal_log(METAL_LOG_INFO, fmt, ##args)
+#define metal_dbg(fmt, args...) metal_log(METAL_LOG_DEBUG, fmt, ##args)
 
 /** @} */
 


### PR DESCRIPTION
See also https://github.com/OpenAMP/libmetal/pull/250
Add "function-name:line-number" prefix and a new-line suffix for all messages. Use do-while(0) to define the metal_log macro. Add convenience macros ML_ERR, ML_WRN, ML_INF, ML_DBG to avoid using excessively long and redundant "metal_log(METAL_LOG_*".

I had to change s/irq/IRQ/ to fix the checkpatch warning: 
`EMBEDDED_FUNCTION_NAME: Prefer using '"%s...", __func__' to using 'irq', this function's name, in a string`