### PR TITLE
README: Point people to the offical docs not the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and request memory across the following operating environments:
   * Bare-metal environments
 
 For more details on the framework please refer to the
-[OpenAMP wiki](https://github.com/OpenAMP/open-amp/wiki).
+[OpenAMP Docs](https://openamp.readthedocs.io/en/latest/).
 
 ## Project configuration
 


### PR DESCRIPTION
The content from the wiki has been moved to the Sphinx based OpenAMP-docs. (Meeting notes will continue to be in the wiki only.)

The wiki data is probably out of date and will get more out of date as we go.

So point people to the official docs.
(Separately we plan to delete the non-meeting note wiki pages.)