### PR TITLE
Docs: fix for the readthedocs PR rendering

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,7 +22,8 @@ build:
       - git clone --recurse-submodules https://github.com/OpenAMP/openamp-docs.git
       # now adjust the focused submodule to the PR in progress
       - echo "URL=${READTHEDOCS_GIT_CLONE_URL} COMMIT=${READTHEDOCS_GIT_COMMIT_HASH}"
-      - (cd openamp-docs/libmetal; git remote add this_pr ${READTHEDOCS_GIT_CLONE_URL}; git fetch this_pr )
+      - (cd openamp-docs/libmetal; git remote add this_pr ../../.git )
+      - (cd openamp-docs/libmetal; git fetch this_pr $(cd ../..; git rev-parse HEAD) )
       - (cd openamp-docs/libmetal; git checkout $(cd ../..; git rev-parse HEAD) )
       - (cd openamp-docs/libmetal; git log -n 1 --oneline)
       - (cd openamp-docs; git submodule status)


### PR DESCRIPTION
The original procedure worked only when the PR was coming from the same repo that was the target of the PR.  This is not normally the case.

The original check out has the commit we need.  Just use it as the remote, fetch and checkout the commit hash we need.