### PR TITLE
test: Zephyr: Replace k_mem_block usage

### DIFF
--- a/test/system/zephyr/main.c
+++ b/test/system/zephyr/main.c
@@ -16,7 +16,7 @@
 #define BLK_NUM_MAX 16
 
 K_HEAP_DEFINE(kmpool, BLK_SIZE_MAX * BLK_NUM_MAX);
-struct k_mem_block block[BLK_NUM_MAX];
+void *block[BLK_NUM_MAX];
 
 extern int init_system(void);
 extern void metal_generic_default_poll(void);
@@ -29,15 +29,15 @@ extern void metal_test_add_mutex();
 extern void *metal_zephyr_allocate_memory(unsigned int size)
 {
 	int i;
-	struct k_mem_block *blk;
+	void **blk;
 
 	for (i = 0; i < sizeof(block)/sizeof(block[0]); i++) {
 		blk = &block[i];
-		if (!blk->data) {
-			blk->data = k_heap_alloc(&kmpool, size, K_NO_WAIT);
-			if (!blk->data)
+		if (!blk) {
+			*blk = k_heap_alloc(&kmpool, size, K_NO_WAIT);
+			if (!*blk)
 				printk("Failed to alloc 0x%x memory.\n", size);
-			return blk->data;
+			return *blk;
 		}
 	}
 
@@ -48,13 +48,13 @@ extern void *metal_zephyr_allocate_memory(unsigned int size)
 extern void metal_zephyr_free_memory(void *ptr)
 {
 	int i;
-	struct k_mem_block *blk;
+	void **blk;
 
 	for (i = 0; i < sizeof(block)/sizeof(block[0]); i++) {
 		blk = &block[i];
-		if (blk->data == ptr) {
-			k_heap_free(&kmpool, blk);
-			blk->data = NULL;
+		if (*blk == ptr) {
+			k_heap_free(&kmpool, *blk);
+			*blk = NULL;
 			return;
 		}
 	}


### PR DESCRIPTION
The k_mem_block structure is obsolete for some years replace it by a "void *" pointer. as done in Zephyr.

This PR fixes following CI error for Zephyr tests:
```
/github/workspace/test/system/zephyr/main.c:19:20: error: array type has incomplete element type 'struct k_mem_block'
78014
   19 | struct k_mem_block block[BLK_NUM_MAX];
78015
      |                    ^~~~~
78016
/github/workspace/test/system/zephyr/main.c: In function 'metal_zephyr_allocate_memory':
78017
/github/workspace/test/system/zephyr/main.c:36:25: error: invalid use of undefined type 'struct k_mem_block'
78018
   36 |                 if (!blk->data) {
78019
      |                         ^~
78020
/github/workspace/test/system/zephyr/main.c:37:28: error: invalid use of undefined type 'struct k_mem_block'
78021
   37 |                         blk->data = k_heap_alloc(&kmpool, size, K_NO_WAIT);
78022
      |                            ^~
78023
/github/workspace/test/system/zephyr/main.c:38:33: error: invalid use of undefined type 'struct k_mem_block'
78024
   38 |                         if (!blk->data)
78025
      |                                 ^~
78026
/github/workspace/test/system/zephyr/main.c:40:35: error: invalid use of undefined type 'struct k_mem_block'
78027
   40 |                         return blk->data;
78028
      |                                   ^~
78029
/github/workspace/test/system/zephyr/main.c: In function 'metal_zephyr_free_memory':
78030
/github/workspace/test/system/zephyr/main.c:55:24: error: invalid use of undefined type 'struct k_mem_block'
78031
   55 |                 if (blk->data == ptr) {
78032
      |                        ^~
78033
/github/workspace/test/system/zephyr/main.c:57:28: error: invalid use of undefined type 'struct k_mem_block'
78034
   57 |                         blk->data = NULL;
78035
      |                            ^~
78036
make[2]: *** [CMakeFiles/app.dir/build.make:76: CMakeFiles/app.dir/test/system/zephyr/main.c.obj] Error 1
78037
make[1]: *** [CMakeFiles/Makefile2:2779: CMakeFiles/app.dir/all] Error 2
```