### PR TITLE
Minor improvements in entrypoint CI script

### DIFF
--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -44,7 +44,7 @@ build_generic(){
 build_freertos(){
 	echo  " Build for freertos OS "
       	apt-get install -y gcc-arm-none-eabi unzip &&
-      	wget $FREERTOS_ZIP_URL > /dev/null &&
+      	wget $FREERTOS_ZIP_URL --dot-style=giga > /dev/null &&
       	unzip FreeRTOSv10.0.1.zip > /dev/null &&
 	mkdir -p build-freertos &&
 	cd build-freertos && export &&
@@ -56,7 +56,7 @@ build_freertos(){
 build_zephyr(){
 	echo  " Build for Zephyr OS "
 	sudo apt-get install -y git cmake ninja-build gperf || exit 1
-  	sudo apt-get install -y ccache dfu-util device-tree-compiler wget || exit 1
+  	sudo apt-get install -y ccache dfu-util device-tree-compiler wget pv || exit 1
   	sudo apt-get install -y python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file || exit 1
   	sudo apt-get install -y make gcc gcc-multilib g++-multilib libsdl2-dev || exit 1
 	sudo apt-get install -y libc6-dev-i386 gperf g++ python3-ply python3-yaml device-tree-compiler ncurses-dev uglifyjs -qq || exit 1
@@ -65,8 +65,9 @@ build_zephyr(){
 	echo 'export PATH=~/.local/bin:"$PATH"' >> ~/.bashrc
 	source ~/.bashrc
 
-	wget $ZEPHYR_SDK_DOWNLOAD_URL || exit 1
-	tar xvf $ZEPHYR_SDK_SETUP_TAR || exit 1
+	wget $ZEPHYR_SDK_DOWNLOAD_URL --dot-style=giga || exit 1
+	echo "Extracting $ZEPHYR_SDK_SETUP_TAR"
+	pv $ZEPHYR_SDK_SETUP_TAR -i 3 -ptebr -f | tar xJ || exit 1
 	rm -rf $ZEPHYR_SDK_INSTALL_DIR || exit 1
 	yes | ./$ZEPHYR_SDK_SETUP_DIR/setup.sh || exit 1
 	west init ./zephyrproject || exit 1

--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -77,7 +77,7 @@ build_zephyr(){
 	yes | ./$ZEPHYR_SDK_SETUP_DIR/setup.sh || exit 1
 	west init ./zephyrproject || exit 1
 	cd ./zephyrproject || exit 1
-	west update || exit 1
+	west update --narrow || exit 1
 	west zephyr-export || exit 1
 	pip3 install --user -r ./zephyr/scripts/requirements.txt || exit 1
 

--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -17,8 +17,8 @@ pre_build(){
 	echo 'Etc/UTC' > /etc/timezone &&
 	ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime &&
 	apt update &&
-   	apt-get install -y make || exit 1
-   	sudo pip3 install cmake || exit 1
+	apt-get install -y make || exit 1
+	sudo pip3 install cmake || exit 1
 }
 
 build_linux(){
@@ -33,7 +33,7 @@ build_linux(){
 
 build_generic(){
 	echo  " Build for generic platform "
-      	apt-get install -y gcc-arm-none-eabi &&
+	apt-get install -y gcc-arm-none-eabi &&
 	mkdir -p build-generic &&
 	cd build-generic &&
 	cmake .. -DCMAKE_TOOLCHAIN_FILE=template-generic &&
@@ -48,7 +48,10 @@ build_freertos(){
       	unzip FreeRTOSv10.0.1.zip > /dev/null &&
 	mkdir -p build-freertos &&
 	cd build-freertos && export &&
-      	cmake .. -DCMAKE_TOOLCHAIN_FILE=template-freertos -DCMAKE_C_FLAGS="-I$PWD/../FreeRTOSv10.0.1/FreeRTOS/Source/include/ -I$PWD/../FreeRTOSv10.0.1/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley -I$PWD/../FreeRTOSv10.0.1/FreeRTOS/Source/portable/GCC/ARM_CM3" &&
+	cmake .. -DCMAKE_TOOLCHAIN_FILE=template-freertos \
+		-DCMAKE_C_FLAGS="-I$PWD/../FreeRTOSv10.0.1/FreeRTOS/Source/include/ \
+		-I$PWD/../FreeRTOSv10.0.1/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley \
+		-I$PWD/../FreeRTOSv10.0.1/FreeRTOS/Source/portable/GCC/ARM_CM3" &&
 	make VERBOSE=1 &&
 	exit 0
 }
@@ -56,10 +59,12 @@ build_freertos(){
 build_zephyr(){
 	echo  " Build for Zephyr OS "
 	sudo apt-get install -y git cmake ninja-build gperf || exit 1
-  	sudo apt-get install -y ccache dfu-util device-tree-compiler wget pv || exit 1
-  	sudo apt-get install -y python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file || exit 1
-  	sudo apt-get install -y make gcc gcc-multilib g++-multilib libsdl2-dev || exit 1
-	sudo apt-get install -y libc6-dev-i386 gperf g++ python3-ply python3-yaml device-tree-compiler ncurses-dev uglifyjs -qq || exit 1
+	sudo apt-get install -y ccache dfu-util device-tree-compiler wget pv || exit 1
+	sudo apt-get install -y python3-dev python3-pip python3-setuptools python3-tk \
+		python3-wheel xz-utils file || exit 1
+	sudo apt-get install -y make gcc gcc-multilib g++-multilib libsdl2-dev || exit 1
+	sudo apt-get install -y libc6-dev-i386 gperf g++ python3-ply python3-yaml \
+		device-tree-compiler ncurses-dev uglifyjs -qq || exit 1
 	sudo pip3 install pyelftools || exit 1
 	pip3 install --user -U west
 	echo 'export PATH=~/.local/bin:"$PATH"' >> ~/.bashrc
@@ -76,8 +81,8 @@ build_zephyr(){
 	west zephyr-export || exit 1
 	pip3 install --user -r ./zephyr/scripts/requirements.txt || exit 1
 
-    	cd ./zephyr &&
-    	source zephyr-env.sh &&
+	cd ./zephyr &&
+	source zephyr-env.sh &&
 	cd ../.. &&
 	# The prj.conf is mandatory for cmake execution, create a void file.
 	touch prj.conf &&
@@ -85,19 +90,19 @@ build_zephyr(){
 	# version.cmake file
  	echo "PATCHLEVEL = 0" >>VERSION &&
  	echo "VERSION_TWEAK = 0" >>VERSION &&
-        echo  "###### Build for qemu_cortex_m3 ######" &&
-        cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_m3 -DWITH_TESTS=on -Bbuild-zephyr-m3 &&
-        cd build-zephyr-m3 &&
-        make VERBOSE=1 &&
-        cd .. &&
-        echo  "###### Build for qemu_cortex_a53 ######" &&
-        cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_a53 -DWITH_TESTS=on -Bbuild-zephyr-a53 &&
-        cd build-zephyr-a53 &&
-        make VERBOSE=1 &&
-        cd .. &&
-        echo  "###### Build for qemu_xtensa ######" &&
-        cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_xtensa -DWITH_TESTS=on -Bbuild-zephyr-xtensa &&
-        cd build-zephyr-xtensa &&
+	echo  "###### Build for qemu_cortex_m3 ######" &&
+	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_m3 -DWITH_TESTS=on -Bbuild-zephyr-m3 &&
+	cd build-zephyr-m3 &&
+	make VERBOSE=1 &&
+	cd .. &&
+	echo  "###### Build for qemu_cortex_a53 ######" &&
+	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_a53 -DWITH_TESTS=on -Bbuild-zephyr-a53 &&
+	cd build-zephyr-a53 &&
+	make VERBOSE=1 &&
+	cd .. &&
+	echo  "###### Build for qemu_xtensa ######" &&
+	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_xtensa -DWITH_TESTS=on -Bbuild-zephyr-xtensa &&
+	cd build-zephyr-xtensa &&
 	cd .. &&
 	echo  "###### Build for qemu_riscv64 ######" &&
 	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_riscv64 -DWITH_TESTS=on -Bbuild-zephyr-rscv64 &&
@@ -115,17 +120,17 @@ main(){
 	pre_build;
 
 	if [[ "$TARGET" == "linux" ]]; then
-   		build_linux
-   	fi
+		build_linux
+	fi
 	if [[ "$TARGET" == "generic" ]]; then
-   		build_generic
-   	fi
+		build_generic
+	fi
 	if [[ "$TARGET" == "freertos" ]]; then
-   		build_freertos
-   	fi
+		build_freertos
+	fi
 	if [[ "$TARGET" == "zephyr" ]]; then
-   		build_zephyr
-   	fi
+		build_zephyr
+	fi
 }
 
 main


### PR DESCRIPTION
A few minor changes to the CI script to reduce considerably the log size and do a minor speed up.
There are 3 main changes:
* wget prints less as it progresses (one dot per megabyte instead of KB) (~10K lines saved)
* The zephyr SDK extraction, instead of printing one line per file (~50K lines), it prints a progress bar updated every 3 seconds.
* west does a narrow update instead of a full update (only fetching the needed branch for each repo)