### PR TITLE
lib: compiler support of arm compiler v6

### DIFF
--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -100,7 +100,7 @@ using std::atomic_fetch_and_explicit;
 using std::atomic_thread_fence;
 using std::atomic_signal_fence;
 
-#elif defined(HAVE_STDATOMIC_H) && !defined(__CC_ARM) && \
+#elif defined(HAVE_STDATOMIC_H) && !defined(__CC_ARM) && !defined(__arm__) && \
       !defined(__STDC_NO_ATOMICS__)
 # include <stdint.h>
 # include <stdatomic.h>

--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -16,7 +16,7 @@
 # include <metal/compiler/gcc/compiler.h>
 #elif defined(__ICCARM__)
 # include <metal/compiler/iar/compiler.h>
-#elif defined(__CC_ARM)
+#elif defined(__CC_ARM) || defined(__arm__)
 # error "MDK-ARM ARMCC compiler requires the GNU extensions to work correctly"
 #else
 # error "Missing compiler support"

--- a/lib/errno.h
+++ b/lib/errno.h
@@ -14,7 +14,7 @@
 
 #if defined(__ICCARM__)
 # include <metal/compiler/iar/errno.h>
-#elif defined(__CC_ARM)
+#elif defined(__CC_ARM) || defined(__arm__)
 # include <metal/compiler/armcc/errno.h>
 #else
 # include <errno.h>


### PR DESCRIPTION
The predefined macro __CC_ARM available on 5.x is migrated to the macro __arm__ for the version 6.x. Add defines to support both versions.

See https://developer.arm.com/documentation/ka005069/1-0/?lang=en for details