### PR TITLE
zephyr: use k_cpu_idle instead of arch_cpu_idle

### DIFF
--- a/lib/system/zephyr/sys.c
+++ b/lib/system/zephyr/sys.c
@@ -12,12 +12,12 @@
 #include <metal/io.h>
 #include <metal/sys.h>
 
-#include <zephyr/sys/arch_interface.h>
+#include <zephyr/kernel.h>
 
 /**
  * @brief poll function until some event happens
  */
 void metal_weak metal_generic_default_poll(void)
 {
-	arch_cpu_idle();
+	k_cpu_idle();
 }


### PR DESCRIPTION
arch_cpu_idle() is an internal API that should not be used outside of the main Zephyr. Use k_cpu_idle() instead, which is the same thing (at least for now).