### PR TITLE
lib: system: MPU flag check fix for xilinx platform

### DIFF
--- a/lib/system/freertos/xlnx/sys.c
+++ b/lib/system/freertos/xlnx/sys.c
@@ -96,7 +96,7 @@ void *metal_machine_io_mem_map_versal_net(void *va, metal_phys_addr_t pa,
 
 	for (cnt = 0; cnt < MAX_POSSIBLE_MPU_REGS; cnt++) {
 
-		if (!mpu_config[cnt].flags & XMPU_VALID_REGION)
+		if (!(mpu_config[cnt].flags & XMPU_VALID_REGION))
 			continue;
 
 		base_end_addr =  mpu_config[cnt].Size + mpu_config[cnt].BaseAddress;

--- a/lib/system/generic/xlnx/sys.c
+++ b/lib/system/generic/xlnx/sys.c
@@ -93,7 +93,7 @@ void *metal_machine_io_mem_map_versal_net(void *va, metal_phys_addr_t pa,
 
 	for (cnt = 0; cnt < MAX_POSSIBLE_MPU_REGS; cnt++) {
 
-		if (!mpu_config[cnt].flags & XMPU_VALID_REGION)
+		if (!(mpu_config[cnt].flags & XMPU_VALID_REGION))
 			continue;
 
 		base_end_addr =  mpu_config[cnt].Size + mpu_config[cnt].BaseAddress;


### PR DESCRIPTION
Check if valid MPU flag is set or not. Current condition checks if flag is 0 or not, which is not intended use of flags