### PR TITLE
lib: system: zephyr: Use default metal_generic_bus

### DIFF
--- a/lib/system/zephyr/device.c
+++ b/lib/system/zephyr/device.c
@@ -22,15 +22,3 @@ int metal_generic_dev_sys_open(struct metal_device *dev)
 	 */
 	return 0;
 }
-
-struct metal_bus metal_generic_bus = {
-	.name = "generic",
-	.ops  = {
-		.bus_close = NULL,
-		.dev_open  = metal_generic_dev_open,
-		.dev_close = NULL,
-		.dev_irq_ack = NULL,
-		.dev_dma_map = NULL,
-		.dev_dma_unmap = NULL,
-	},
-};


### PR DESCRIPTION
The only difference is the DMA ops, which the generic ops turns into simple cache operation which zephyr does support.