### PR TITLE
lib: Do not label function declarations in headers with extern

### DIFF
--- a/lib/device.h
+++ b/lib/device.h
@@ -86,14 +86,14 @@ struct metal_device {
  * @param[in]	bus	Pre-initialized bus structure.
  * @return 0 on success, or -errno on failure.
  */
-extern int metal_bus_register(struct metal_bus *bus);
+int metal_bus_register(struct metal_bus *bus);
 
 /**
  * @brief	Unregister a libmetal bus.
  * @param[in]	bus	Pre-registered bus structure.
  * @return 0 on success, or -errno on failure.
  */
-extern int metal_bus_unregister(struct metal_bus *bus);
+int metal_bus_unregister(struct metal_bus *bus);
 
 /**
  * @brief	Find a libmetal bus by name.
@@ -101,7 +101,7 @@ extern int metal_bus_unregister(struct metal_bus *bus);
  * @param[out]	bus	Returned bus handle.
  * @return 0 on success, or -errno on failure.
  */
-extern int metal_bus_find(const char *name, struct metal_bus **bus);
+int metal_bus_find(const char *name, struct metal_bus **bus);
 
 /**
  * @brief	Statically register a generic libmetal device.
@@ -118,7 +118,7 @@ extern int metal_bus_find(const char *name, struct metal_bus **bus);
  * @param[in]	device	Generic device.
  * @return 0 on success, or -errno on failure.
  */
-extern int metal_register_generic_device(struct metal_device *device);
+int metal_register_generic_device(struct metal_device *device);
 
 /**
  * @brief	Open a libmetal device by name.
@@ -127,14 +127,14 @@ extern int metal_register_generic_device(struct metal_device *device);
  * @param[out]	device		Returned device handle.
  * @return 0 on success, or -errno on failure.
  */
-extern int metal_device_open(const char *bus_name, const char *dev_name,
-			     struct metal_device **device);
+int metal_device_open(const char *bus_name, const char *dev_name,
+		      struct metal_device **device);
 
 /**
  * @brief	Close a libmetal device.
  * @param[in]	device		Device handle.
  */
-extern void metal_device_close(struct metal_device *device);
+void metal_device_close(struct metal_device *device);
 
 /**
  * @brief	Get an I/O region accessor for a device region.
@@ -154,20 +154,16 @@ metal_device_io_region(struct metal_device *device, unsigned int index)
 /** @} */
 
 #ifdef METAL_INTERNAL
-extern int metal_generic_dev_sys_open(struct metal_device *dev);
-extern int metal_generic_dev_open(struct metal_bus *bus, const char *dev_name,
-				  struct metal_device **device);
-extern int metal_generic_dev_dma_map(struct metal_bus *bus,
-				     struct metal_device *device,
-				     uint32_t dir,
-				     struct metal_sg *sg_in,
-				     int nents_in,
-				     struct metal_sg *sg_out);
-extern void metal_generic_dev_dma_unmap(struct metal_bus *bus,
-					struct metal_device *device,
-					uint32_t dir,
-					struct metal_sg *sg,
-					int nents);
+int metal_generic_dev_sys_open(struct metal_device *dev);
+int metal_generic_dev_open(struct metal_bus *bus, const char *dev_name,
+			   struct metal_device **device);
+int metal_generic_dev_dma_map(struct metal_bus *bus,
+			      struct metal_device *device,
+			      uint32_t dir, struct metal_sg *sg_in,
+			      int nents_in, struct metal_sg *sg_out);
+void metal_generic_dev_dma_unmap(struct metal_bus *bus,
+				 struct metal_device *device,
+				 uint32_t dir, struct metal_sg *sg, int nents);
 #endif /* METAL_INTERNAL */
 
 #ifdef __cplusplus

--- a/lib/log.h
+++ b/lib/log.h
@@ -41,25 +41,25 @@ typedef void (*metal_log_handler)(enum metal_log_level level,
  * @param[in]	handler	log message handler.
  * @return	0 on success, or -errno on failure.
  */
-extern void metal_set_log_handler(metal_log_handler handler);
+void metal_set_log_handler(metal_log_handler handler);
 
 /**
  * @brief	Get the current libmetal log handler.
  * @return	Current log handler.
  */
-extern metal_log_handler metal_get_log_handler(void);
+metal_log_handler metal_get_log_handler(void);
 
 /**
  * @brief	Set the level for libmetal logging.
  * @param[in]	level	log message level.
  */
-extern void metal_set_log_level(enum metal_log_level level);
+void metal_set_log_level(enum metal_log_level level);
 
 /**
  * @brief	Get the current level for libmetal logging.
  * @return	Current log level.
  */
-extern enum metal_log_level metal_get_log_level(void);
+enum metal_log_level metal_get_log_level(void);
 
 /**
  * @brief	Default libmetal log handler.  This handler prints libmetal log
@@ -68,8 +68,8 @@ extern enum metal_log_level metal_get_log_level(void);
  * @param[in]	format	log message format string.
  * @return	0 on success, or -errno on failure.
  */
-extern void metal_default_log_handler(enum metal_log_level level,
-				      const char *format, ...);
+void metal_default_log_handler(enum metal_log_level level,
+			       const char *format, ...);
 
 /**
  * @internal

--- a/lib/shmem.h
+++ b/lib/shmem.h
@@ -41,8 +41,8 @@ struct metal_generic_shmem {
  *
  * @see metal_shmem_create
  */
-extern int metal_shmem_open(const char *name, size_t size,
-			    struct metal_io_region **io);
+int metal_shmem_open(const char *name, size_t size,
+		     struct metal_io_region **io);
 
 /**
  * @brief	Statically register a generic shared memory region.
@@ -55,7 +55,7 @@ extern int metal_shmem_open(const char *name, size_t size,
  * @param[in]	shmem	Generic shmem structure.
  * @return 0 on success, or -errno on failure.
  */
-extern int metal_shmem_register_generic(struct metal_generic_shmem *shmem);
+int metal_shmem_register_generic(struct metal_generic_shmem *shmem);
 
 #ifdef METAL_INTERNAL
 

--- a/lib/sys.h
+++ b/lib/sys.h
@@ -106,7 +106,7 @@ extern struct metal_state _metal;
  *
  * @see metal_finish
  */
-extern int metal_init(const struct metal_init_params *params);
+int metal_init(const struct metal_init_params *params);
 
 /**
  * @brief	Shutdown libmetal.
@@ -115,7 +115,7 @@ extern int metal_init(const struct metal_init_params *params);
  *
  * @see metal_init
  */
-extern void metal_finish(void);
+void metal_finish(void);
 
 #ifdef METAL_INTERNAL
 
@@ -129,7 +129,7 @@ extern void metal_finish(void);
  * @param[in]	params	Initialization parameters (@see metal_init_params).
  * @return	0 on success, or -errno on failure.
  */
-extern int metal_sys_init(const struct metal_init_params *params);
+int metal_sys_init(const struct metal_init_params *params);
 
 /**
  * @brief	libmetal system shutdown.
@@ -139,7 +139,7 @@ extern int metal_sys_init(const struct metal_init_params *params);
  *
  * @see metal_sys_init
  */
-extern void metal_sys_finish(void);
+void metal_sys_finish(void);
 
 #endif
 

--- a/lib/system/freertos/cache.h
+++ b/lib/system/freertos/cache.h
@@ -20,8 +20,8 @@
 extern "C" {
 #endif
 
-extern void metal_machine_cache_flush(void *addr, unsigned int len);
-extern void metal_machine_cache_invalidate(void *addr, unsigned int len);
+void metal_machine_cache_flush(void *addr, unsigned int len);
+void metal_machine_cache_invalidate(void *addr, unsigned int len);
 
 static inline void __metal_cache_flush(void *addr, unsigned int len)
 {

--- a/lib/system/generic/cache.h
+++ b/lib/system/generic/cache.h
@@ -20,8 +20,8 @@
 extern "C" {
 #endif
 
-extern void metal_machine_cache_flush(void *addr, unsigned int len);
-extern void metal_machine_cache_invalidate(void *addr, unsigned int len);
+void metal_machine_cache_flush(void *addr, unsigned int len);
+void metal_machine_cache_invalidate(void *addr, unsigned int len);
 
 static inline void __metal_cache_flush(void *addr, unsigned int len)
 {

--- a/lib/system/linux/sys.h
+++ b/lib/system/linux/sys.h
@@ -95,23 +95,23 @@ struct metal_state {
 };
 
 #ifdef METAL_INTERNAL
-extern int metal_linux_bus_init(void);
-extern void metal_linux_bus_finish(void);
+int metal_linux_bus_init(void);
+void metal_linux_bus_finish(void);
 
-extern int metal_open(const char *path, int shm);
-extern int metal_open_unlinked(const char *path, int shm);
-extern int metal_mktemp(char *template, int fifo);
-extern int metal_mktemp_unlinked(char *template);
+int metal_open(const char *path, int shm);
+int metal_open_unlinked(const char *path, int shm);
+int metal_mktemp(char *template, int fifo);
+int metal_mktemp_unlinked(char *template);
 
-extern int metal_map(int fd, off_t offset, size_t size, int expand,
-		     int flags, void **result);
-extern int metal_unmap(void *mem, size_t size);
-extern int metal_mlock(void *mem, size_t size);
+int metal_map(int fd, off_t offset, size_t size, int expand,
+	      int flags, void **result);
+int metal_unmap(void *mem, size_t size);
+int metal_mlock(void *mem, size_t size);
 
-extern void metal_randomize_string(char *template);
-extern void metal_mktemp_template(char template[PATH_MAX],
-				  const char *name);
-extern int metal_virt2phys(void *addr, unsigned long *phys);
+void metal_randomize_string(char *template);
+void metal_mktemp_template(char template[PATH_MAX],
+			   const char *name);
+int metal_virt2phys(void *addr, unsigned long *phys);
 
 /**
  * @brief	Read a device tree property of a device
@@ -122,9 +122,9 @@ extern int metal_virt2phys(void *addr, unsigned long *phys);
  * @param[in]	len number of bytes to be read
  * @return	0 on success, or -errno on error.
  */
-extern int metal_linux_get_device_property(struct metal_device *device,
-					   const char *property_name,
-					   void *output, int len);
+int metal_linux_get_device_property(struct metal_device *device,
+				    const char *property_name,
+				    void *output, int len);
 
 #define metal_for_each_page_size_up(ps)					\
 	for ((ps) = &_metal.page_sizes[0];				\

--- a/lib/version.h
+++ b/lib/version.h
@@ -30,7 +30,7 @@ extern "C" {
  *  @return	Library major version number.
  *  @see	METAL_VER_MAJOR
  */
-extern int metal_ver_major(void);
+int metal_ver_major(void);
 
 /**
  *  @brief	Library minor version number.
@@ -42,7 +42,7 @@ extern int metal_ver_major(void);
  *  @return	Library minor version number.
  *  @see	METAL_VER_MINOR
  */
-extern int metal_ver_minor(void);
+int metal_ver_minor(void);
 
 /**
  *  @brief	Library patch level.
@@ -54,7 +54,7 @@ extern int metal_ver_minor(void);
  *  @return	Library patch level.
  *  @see	METAL_VER_PATCH
  */
-extern int metal_ver_patch(void);
+int metal_ver_patch(void);
 
 /**
  *  @brief	Library version string.
@@ -66,7 +66,7 @@ extern int metal_ver_patch(void);
  *  @return	Library version string.
  *  @see	METAL_VER
  */
-extern const char *metal_ver(void);
+const char *metal_ver(void);
 
 /** @} */
 


### PR DESCRIPTION
This is not needed for function declarations, they already have implicit external linkage.
