### PR TITLE
CI: fix timezone and pip3 issues

### DIFF
--- a/.github/actions/build_ci/Dockerfile
+++ b/.github/actions/build_ci/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:latest
+FROM ubuntu:24.04
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # Install prerequisites
-RUN apt-get --quiet=2 update && apt-get install --quiet=2 --assume-yes sudo git python3 python3-pip wget
+RUN apt-get --quiet=2 update && apt-get install --quiet=2 --assume-yes sudo git python3 python3-pip python3-venv wget
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -6,7 +6,7 @@ ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 ZEPHYR_SDK_API_FOLDER=https://api.github.com/repos/zephyrproject-rtos/sdk-ng/releases/latest
 ZEPHYR_SDK_SETUP_TAR=zephyr-sdk-.*linux-x86_64.tar.xz
 
-FREERTOS_ZIP_URL=https://cfhcable.dl.sourceforge.net/project/freertos/FreeRTOS/V10.0.1/FreeRTOSv10.0.1.zip
+FREERTOS_ZIP_URL=https://sourceforge.net/projects/freertos/files/FreeRTOS/V10.0.1/FreeRTOSv10.0.1.zip
 
 pre_build(){
 	# fix issue related to tzdata install, not needed for 24.04 but kept for 22.04 and earlier

--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -40,8 +40,8 @@ build_generic(){
 	apt-get install -y gcc-arm-none-eabi &&
 	mkdir -p build-generic &&
 	cd build-generic &&
-	cmake .. -DCMAKE_TOOLCHAIN_FILE=template-generic &&
-	make VERBOSE=1 &&
+	cmake .. -DCMAKE_TOOLCHAIN_FILE=template-generic || exit 1
+	make VERBOSE=1 || exit 1
 	exit 0
 }
 
@@ -55,8 +55,8 @@ build_freertos(){
 	cmake .. -DCMAKE_TOOLCHAIN_FILE=template-freertos \
 		-DCMAKE_C_FLAGS="-I$PWD/../FreeRTOSv10.0.1/FreeRTOS/Source/include/ \
 		-I$PWD/../FreeRTOSv10.0.1/FreeRTOS/Demo/CORTEX_STM32F107_GCC_Rowley \
-		-I$PWD/../FreeRTOSv10.0.1/FreeRTOS/Source/portable/GCC/ARM_CM3" &&
-	make VERBOSE=1 &&
+		-I$PWD/../FreeRTOSv10.0.1/FreeRTOS/Source/portable/GCC/ARM_CM3" || exit 1
+	make VERBOSE=1 || exit 1
 	exit 0
 }
 
@@ -98,28 +98,31 @@ build_zephyr(){
  	echo "PATCHLEVEL = 0" >>VERSION &&
  	echo "VERSION_TWEAK = 0" >>VERSION &&
 	echo  "###### Build for qemu_cortex_m3 ######" &&
-	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_m3 -DWITH_TESTS=on -Bbuild-zephyr-m3 &&
-	cd build-zephyr-m3 &&
-	make VERBOSE=1 &&
+	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_m3 -DWITH_TESTS=on -Bbuild-zephyr-m3 || exit 1
+	cd build-zephyr-m3  || exit 1
+	make VERBOSE=1 || exit 1
 	cd .. &&
 	echo  "###### Build for qemu_cortex_a53 ######" &&
-	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_a53 -DWITH_TESTS=on -Bbuild-zephyr-a53 &&
+	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_cortex_a53 -DWITH_TESTS=on -Bbuild-zephyr-a53 \
+		|| exit 1
 	cd build-zephyr-a53 &&
-	make VERBOSE=1 &&
+	make VERBOSE=1  || exit 1
 	cd .. &&
 	echo  "###### Build for qemu_xtensa ######" &&
 	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_xtensa -DWITH_TESTS=on -Bbuild-zephyr-xtensa &&
 	cd build-zephyr-xtensa &&
 	cd .. &&
 	echo  "###### Build for qemu_riscv64 ######" &&
-	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_riscv64 -DWITH_TESTS=on -Bbuild-zephyr-rscv64 &&
+	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_riscv64 -DWITH_TESTS=on -Bbuild-zephyr-rscv64 \
+		|| exit 1
 	cd build-zephyr-rscv64 &&
-	make VERBOSE=1 &&
+	make VERBOSE=1  || exit 1
 	cd .. &&
 	echo  "###### Build for qemu_riscv32 ######" &&
-	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_riscv32 -DWITH_TESTS=on -Bbuild-zephyr-rscv32 &&
+	cmake . -DWITH_ZEPHYR=on -DBOARD=qemu_riscv32 -DWITH_TESTS=on -Bbuild-zephyr-rscv32 \
+		|| exit 1
 	cd build-zephyr-rscv32 &&
-	make VERBOSE=1 &&
+	make VERBOSE=1  || exit 1
 	exit 0
 }
 


### PR DESCRIPTION
The build check fails with following errors:

1) ln: failed to create symbolic link '/etc/localtime': File exists
Fix it by removing the link creation

2) error: externally-managed-environment
Fix it by adding "--break-system-packages" option to pip3