### PR TITLE
zynq: Remove support for Zynq-7000 SoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,9 @@ This API is for compiler dependent functions.  For this release, there is only
 a GCC implementation, and compiler specific code is limited to atomic
 operations.
 
+## Deprecated platforms
+  - AMD-Xilinx Zynq7000. Last known stable release - v2023.04
+
 ## How to contribute
 
 As an open-source project, we welcome and encourage the community to submit

--- a/cmake/platforms/zynq7-freertos.cmake
+++ b/cmake/platforms/zynq7-freertos.cmake
@@ -1,9 +1,0 @@
-set (CMAKE_SYSTEM_PROCESSOR "arm"            CACHE STRING "")
-set (MACHINE                "zynq7"          CACHE STRING "")
-set (PROJECT_VENDOR         "xlnx"             CACHE STRING "")
-set (CROSS_PREFIX           "arm-none-eabi-" CACHE STRING "")
-
-set (CMAKE_C_FLAGS          "-mcpu=cortex-a9 -mfpu=vfpv3 -mfloat-abi=hard" CACHE STRING "")
-
-include (cross-freertos-gcc)
-

--- a/cmake/platforms/zynq7-generic-iar.cmake
+++ b/cmake/platforms/zynq7-generic-iar.cmake
@@ -1,5 +1,0 @@
-set (CMAKE_SYSTEM_PROCESSOR "arm" CACHE STRING "")
-set (PROJECT_VENDOR         "xlnx"             CACHE STRING "")
-set (CROSS_SUFFIX           "arm" CACHE STRING "")
-include (cross-generic-iar)
-

--- a/cmake/platforms/zynq7-generic.cmake
+++ b/cmake/platforms/zynq7-generic.cmake
@@ -1,9 +1,0 @@
-set (CMAKE_SYSTEM_PROCESSOR "arm"            CACHE STRING "")
-set (MACHINE                "zynq7"          CACHE STRING "")
-set (PROJECT_VENDOR         "xlnx"             CACHE STRING "")
-set (CROSS_PREFIX           "arm-none-eabi-" CACHE STRING "")
-
-set (CMAKE_C_FLAGS          "-mcpu=cortex-a9 -mfpu=vfpv3 -mfloat-abi=hard" CACHE STRING "")
-
-include (cross-generic-gcc)
-

--- a/cmake/platforms/zynq7-linux.cmake
+++ b/cmake/platforms/zynq7-linux.cmake
@@ -1,4 +1,0 @@
-set (CMAKE_SYSTEM_PROCESSOR "arm"                       CACHE STRING "")
-set (CROSS_PREFIX           "arm-xilinx-linux-gnueabi-" CACHE STRING "")
-include (cross-linux-gcc)
-


### PR DESCRIPTION
Remove support for Zynq-7000 SoC, changes are
1. Remove Zynq7 tool chain support
2. Makefile changes to remove zynq7

Reasons to remove:
1. Support for Zynq-7000 has ended
2. Removing redundant or unmaintained code
3. Reduce technical debt carried by OpenAMP team
4. very few customer using openamp on Zynq-7000 SoC

For using Zynq-7000 SoC support last working and tested version is (v2023.10)
https://github.com/OpenAMP/libmetal/tree/v2023.10