### PR TITLE
CI: fix zephyr build for v3.7 and later

### DIFF
--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -91,8 +91,11 @@ build_zephyr(){
 	cd ./zephyr &&
 	source zephyr-env.sh &&
 	cd ../.. &&
-	# The prj.conf is mandatory for cmake execution, create a void file.
-	touch prj.conf &&
+	# The prj.conf is mandatory for cmake execution, create a file.
+	# The base level of the test framework intentionally uses constructors
+	#   so we must define this config item in v3.7.0 or later
+	#   HOWEVER, this define will cause cmake to fail for v3.6 or earlier
+	echo "CONFIG_STATIC_INIT_GNU=y" >prj.conf &&
 	# Add dummy fields in the VERSION file to fix compatibility with Zephyr
 	# version.cmake file
  	echo "PATCHLEVEL = 0" >>VERSION &&


### PR DESCRIPTION
The current CI uses the latest from main for zephyr build tests. This has been broken sometime after v3.6 and before v3.7 In Zephyr v3.7 and later, use of GNU style constructors requires a kconfig value to be defined.  This same kconfig value will cause an error in v3.6 or earlier.

The test framework intentionally uses GNU constructors for the base level of its framework and version.c uses this to register its test.

The test/system/zephyr/ level overrides the default META_ADD_TEST() macro and creates unique functions that main.c then calls explicitly in function metal_test_add_functions().

Thus, right now the only constructor used is for version.c but it still intentionally used.

Since we use the latest for CI, define the value so CI will complete.

Fixes: #304 