### PR TITLE
CI: Do Zephyr build tests on known good and latest versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ jobs:
     name: check builds on different platforms
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: build for Linux
       id: build_linux
       uses: ./.github/actions/build_ci
@@ -38,7 +38,16 @@ jobs:
       uses: ./.github/actions/build_ci
       with:
         target: freertos
-    - name: build for Zephyr
+
+  # Break the zephyr builds into their own job as the common runner was
+  # running out of space when runs were together
+  # Also, as the longest running jobs, this allows them to run in ||
+  zephyr_build_known_good_version:
+    name: Zephyr build with a version that is known to work
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: build for Zephyr (Known Good)
       id: build_Zephyr
       uses: ./.github/actions/build_ci
       with:
@@ -48,7 +57,7 @@ jobs:
     name: nonreg tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: configure
       run: |
         sudo apt-get update && sudo apt-get install libsysfs-dev

--- a/.github/workflows/heathcheck.yml
+++ b/.github/workflows/heathcheck.yml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Linaro Limited.
+
+# The focus of this flow is to check for external changes that will effect
+# the project.  Even if no code changes are happening, changes in external
+# distros or projects can invalidate our work and this flow lets us know
+
+name: libmetal Heath Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - docs/**
+
+  # Allows you to run this workflow manually from the Actions tab or gh API
+  workflow_dispatch:
+
+  # run weekly on Sunday at 5:10 AM UTC (9:10 PM US western)
+  schedule:
+    - cron:  '10 5 * * 0'
+
+jobs:
+  zephyr_build_main:
+    name: 'Zephyr build from latest on main'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Zephyr Latest
+      id: build_Zephyr_latest
+      uses: ./.github/actions/build_ci
+      with:
+        target: zephyr-latest


### PR DESCRIPTION
Allow Zephyr testing to either use locked known good values or the very latest versions.

The known good versions are best for PR checking as if the build fails it is almost always the PR itself that broke it.

The latest version is good for periodically checking compatibility with the very latest Zephyr changes.

For now we run both on pushes and PRs.

We also run main against the latest zephyr check weekly as a look ahead.

Fixes: #295 