### PR TITLE
lib/cpu.h: create a new libmetal API metal_yield

### DIFF
--- a/lib/system/freertos/sys.h
+++ b/lib/system/freertos/sys.h
@@ -18,6 +18,7 @@
 #define __METAL_FREERTOS_SYS__H__
 
 #include <metal/errno.h>
+#include <metal/cpu.h>
 
 #ifdef XLNX_PLATFORM
 #include <metal/system/freertos/xlnx/sys.h>
@@ -32,6 +33,8 @@ extern "C" {
 #ifndef METAL_MAX_DEVICE_REGIONS
 #define METAL_MAX_DEVICE_REGIONS 1
 #endif
+
+#define metal_yield() metal_cpu_yield()
 
 /** Structure for FreeRTOS libmetal runtime state. */
 struct metal_state {

--- a/lib/system/freertos/template/sys.h
+++ b/lib/system/freertos/template/sys.h
@@ -16,9 +16,13 @@
 #ifndef __METAL_FREERTOS_TEMPLATE_SYS__H__
 #define __METAL_FREERTOS_TEMPLATE_SYS__H__
 
+#include <metal/cpu.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define metal_yield() metal_cpu_yield()
 
 #ifdef METAL_INTERNAL
 

--- a/lib/system/freertos/xlnx/sys.h
+++ b/lib/system/freertos/xlnx/sys.h
@@ -17,12 +17,16 @@
 #ifndef __METAL_FREERTOS_XLNX_SYS__H__
 #define __METAL_FREERTOS_XLNX_SYS__H__
 
+#include <metal/cpu.h>
+
 #include "xscugic.h"
 #include "FreeRTOS.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define metal_yield() metal_cpu_yield()
 
 #if defined(SDT) && defined(PLATFORM_ZYNQ)
 #define XPAR_SCUGIC_0_DIST_BASEADDR XPAR_SCUGIC_DIST_BASEADDR

--- a/lib/system/linux/sys.h
+++ b/lib/system/linux/sys.h
@@ -19,6 +19,7 @@
 #include <fcntl.h>
 #include <libgen.h>
 #include <limits.h>
+#include <metal/cpu.h>
 #include <metal/errno.h>
 #include <pthread.h>
 #include <stdio.h>
@@ -45,6 +46,8 @@ extern "C" {
 
 #define METAL_INVALID_VADDR     NULL
 #define MAX_PAGE_SIZES		32
+
+#define metal_yield() metal_cpu_yield()
 
 struct metal_device;
 

--- a/lib/system/nuttx/sys.h
+++ b/lib/system/nuttx/sys.h
@@ -16,9 +16,13 @@
 #ifndef __METAL_NUTTX_SYS__H__
 #define __METAL_NUTTX_SYS__H__
 
+#include <metal/sleep.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define metal_yield() metal_sleep_usec(1000)
 
 #define METAL_INIT_DEFAULTS				\
 {							\

--- a/lib/system/zephyr/sys.h
+++ b/lib/system/zephyr/sys.h
@@ -16,12 +16,15 @@
 #ifndef __METAL_ZEPHYR_SYS__H__
 #define __METAL_ZEPHYR_SYS__H__
 
+#include <metal/cpu.h>
 #include <stdlib.h>
 #include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define metal_yield() metal_cpu_yield()
 
 #define METAL_INIT_DEFAULTS				\
 {							\


### PR DESCRIPTION
metal_yield would be managed at the OS level and dispatched to metal_cpu_yield, metal_sleep_usec, or others, it is more flexible to manage this in libmetal