### PR TITLE
libmetal/atomic: enable 64-bit atomic by toolchain builtin flags

### DIFF
--- a/lib/io.h
+++ b/lib/io.h
@@ -30,7 +30,8 @@ extern "C" {
  *  @{
  */
 
-#ifdef __MICROBLAZE__
+#if defined(__MICROBLAZE__) || \
+(defined(__GNUC__) && !defined(__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8))
 #define NO_ATOMIC_64_SUPPORT
 #endif
 


### PR DESCRIPTION
Fix compile error:
arm-none-eabi-ld: (remoteproc_virtio.o): in function `metal_io_read': metal/io.h:252: undefined reference to `__atomic_load_8' arm-none-eabi-ld: (remoteproc_virtio.o): in function `metal_io_write': metal/io.h:290: undefined reference to `__atomic_store_8'

Not all 32-bit architectures support 64bit atomic, gcc/clang toolchains have built-in properties to indicate whether support atomic64:

| $ arm-none-eabi-gcc -march=armv7e-m  -dM -E - < /dev/null | grep SYNC | #define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
| #define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
| #define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1