### PR TITLE
atomic.h: fix conflicting type qualifiers compiler error

### DIFF
--- a/lib/atomic.h
+++ b/lib/atomic.h
@@ -100,8 +100,8 @@ using std::atomic_fetch_and_explicit;
 using std::atomic_thread_fence;
 using std::atomic_signal_fence;
 
-#elif defined(HAVE_STDATOMIC_H) && !defined(__CC_ARM) && !defined(__arm__) && \
-      !defined(__STDC_NO_ATOMICS__)
+#elif defined(HAVE_STDATOMIC_H) && !defined(__STDC_NO_ATOMICS__) && \
+((!defined(__CC_ARM) && !defined(__arm__)) || defined(__GNUC__))
 # include <stdint.h>
 # include <stdatomic.h>
 #elif defined(__GNUC__)


### PR DESCRIPTION
fix compiler error:
nuttx/include/metal/compiler/gcc/atomic.h:19:13: error: conflicting type qualifiers for 'atomic_flag'
   19 | typedef int atomic_flag;
      |             ^~~~~~~~~~~
In file included from nuttx/include/nuttx/net/netdev_lowerhalf.h:38,
                 from virtio/virtio-net.c:33:
prebuilts/gcc/linux/arm/lib/gcc/arm-none-eabi/13.2.1/include/
stdatomic.h:233:3: note: previous declaration of 'atomic_flag' with
type 'atomic_flag'
  233 | } atomic_flag;
      |   ^~~~~~~~~~~
nuttx/include/metal/compiler/gcc/atomic.h:20:14: error: conflicting
type qualifiers for 'atomic_char'
   20 | typedef char atomic_char;
                     ^~~~~~~~~~~