### PR TITLE
lib/system/nuttx: fix undeclared parameter compile error

### DIFF
--- a/lib/system/nuttx/device.c
+++ b/lib/system/nuttx/device.c
@@ -13,5 +13,7 @@
 
 int metal_generic_dev_sys_open(struct metal_device *dev)
 {
+	metal_unused(dev);
+
 	return 0;
 }

--- a/lib/system/nuttx/init.c
+++ b/lib/system/nuttx/init.c
@@ -18,6 +18,7 @@ struct metal_state _metal;
 int metal_sys_init(const struct metal_init_params *params)
 {
 	int ret = metal_cntr_irq_init();
+	metal_unused(params);
 
 	if (ret >= 0)
 		ret = metal_bus_register(&metal_generic_bus);

--- a/lib/system/nuttx/io.c
+++ b/lib/system/nuttx/io.c
@@ -14,6 +14,7 @@ static uint64_t metal_io_read_(struct metal_io_region *io,
 			       int width)
 {
 	uint64_t value = 0;
+	metal_unused(order);
 
 	metal_io_block_read(io, offset, &value, width);
 	return value;
@@ -25,6 +26,8 @@ static void metal_io_write_(struct metal_io_region *io,
 			    memory_order order,
 			    int width)
 {
+	metal_unused(order);
+
 	metal_io_block_write(io, offset, &value, width);
 }
 
@@ -35,6 +38,7 @@ static int metal_io_block_read_(struct metal_io_region *io,
 				int len)
 {
 	void *va = metal_io_virt(io, offset);
+	metal_unused(order);
 
 	metal_cache_invalidate(va, len);
 	if (len == 1)
@@ -59,6 +63,7 @@ static int metal_io_block_write_(struct metal_io_region *io,
 				 int len)
 {
 	void *va = metal_io_virt(io, offset);
+	metal_unused(order);
 
 	if (len == 1)
 		*(uint8_t *)va = *(uint8_t *)src;
@@ -84,6 +89,7 @@ static void metal_io_block_set_(struct metal_io_region *io,
 				int len)
 {
 	void *va = metal_io_virt(io, offset);
+	metal_unused(order);
 
 	memset(va, value, len);
 	metal_cache_flush(va, len);
@@ -91,6 +97,7 @@ static void metal_io_block_set_(struct metal_io_region *io,
 
 static void metal_io_close_(struct metal_io_region *io)
 {
+	metal_unused(io);
 }
 
 static metal_phys_addr_t metal_io_offset_to_phys_(struct metal_io_region *io,

--- a/lib/system/nuttx/io.h
+++ b/lib/system/nuttx/io.h
@@ -16,6 +16,8 @@
 #ifndef __METAL_NUTTX_IO__H__
 #define __METAL_NUTTX_IO__H__
 
+#include <metal/utilities.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -39,6 +41,7 @@ struct metal_io_region *metal_io_get_region(void);
  */
 static inline void metal_sys_io_mem_map(struct metal_io_region *io)
 {
+	metal_unused(io);
 }
 #endif
 


### PR DESCRIPTION
fix compile error:
/home/wyr/work/code/project/cardev/nuttx/openamp/libmetal/lib/system/nuttx/device.c:16:22: error: 'io' undeclared (first use in this function)
   16 |         metal_unused(io);
/home/wyr/work/code/project/cardev/nuttx/openamp/libmetal/lib/system/nuttx/device.c:14:53: error: unused parameter 'dev' [-Werror=unused-parameter]
   14 | int metal_generic_dev_sys_open(struct metal_device *dev)
...