### PR TITLE
lib/system/nuttx/io.c: include <stddef.h> in nuttx/io.c

### DIFF
--- a/lib/system/nuttx/io.c
+++ b/lib/system/nuttx/io.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <stddef.h>
 #include <metal/cache.h>
 #include <metal/io.h>
 #include <nuttx/arch.h>


### PR DESCRIPTION
Because nuttx/io.c use NULL and NULL is defined in <stddef.h>