### PR TITLE
lib: system: fix missing metal_yield API for generic systems.

### DIFF
--- a/lib/system/generic/sys.h
+++ b/lib/system/generic/sys.h
@@ -17,6 +17,7 @@
 #define __METAL_GENERIC_SYS__H__
 
 #include <limits.h>
+#include <metal/cpu.h>
 #include <metal/errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -43,6 +44,8 @@ struct metal_state {
 	/** Common (system independent) data. */
 	struct metal_common_state common;
 };
+
+#define metal_yield() metal_cpu_yield()
 
 #ifdef METAL_INTERNAL
 


### PR DESCRIPTION
The metal_yield API needs also to be declared for the baremetal systems. This fix build issue in Open-amp for generic system:

/github/workspace/open-amp/lib/rpmsg/rpmsg_virtio.c:275:17: error: implicit declaration of function 'metal_yield'
275 |                 metal_yield();
    |                 ^~~~~~~~~~~