### PR TITLE
lib: processor: hosted: fix compilation warning in metal_cpu_yield

### DIFF
--- a/lib/processor/CMakeLists.txt
+++ b/lib/processor/CMakeLists.txt
@@ -5,10 +5,13 @@ else()
 	collect (PROJECT_LIB_HEADERS generic/cpu.h)
 endif()
 
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_PROCESSOR}/cpu.c")
+	collect (PROJECT_LIB_SOURCES ${PROJECT_PROCESSOR}/cpu.c)
+endif()
+
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_PROCESSOR}/atomic.h")
 	collect (PROJECT_LIB_HEADERS ${PROJECT_PROCESSOR}/atomic.h)
 	set(HAVE_PROCESSOR_ATOMIC_H 1 CACHE INTERNAL "Have include ${PROJECT_PROCESSOR}/atomic.h")
 else()
 	collect (PROJECT_LIB_HEADERS generic/atomic.h)
 endif()
-

--- a/lib/processor/hosted/cpu.c
+++ b/lib/processor/hosted/cpu.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024, STMicroelectronics.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	zephyr/cpu.c
+ * @brief	hosted libmetal cpu routines.
+ */
+
+#include <metal/sys.h>
+
+void metal_cpu_yield(void)
+{
+	metal_wait_usec(10);
+}

--- a/lib/processor/hosted/cpu.h
+++ b/lib/processor/hosted/cpu.h
@@ -9,14 +9,9 @@
  * @brief	Hosted environment CPU specific primitives
  */
 
-#include <metal/sys.h>
-
 #ifndef __METAL_HOSTED_CPU__H__
 #define __METAL_HOSTED_CPU__H__
 
-static inline void metal_cpu_yield(void)
-{
-	metal_wait_usec(10);
-}
+void metal_cpu_yield(void);
 
 #endif /* __METAL_HOSTED_CPU__H__ */


### PR DESCRIPTION
Fix cross inclusion between metal/sys.h and /processor/hosted/cpu.h replacing metal_wait_usec by k_busy_wait function call.

Issue reported by Zephyr twister CI test: https://github.com/zephyrproject-rtos/zephyr/actions/runs/11482800628/job/31962168738?pr=80324

libmetal/lib/include/metal/processor/hosted/cpu.h:19:9: error: implicit declaration of function ‘metal_wait_usec’
   19 |         metal_wait_usec(10);
      |         ^~~~~~~~~~~~~~~
libmetal/lib/include/metal/system/zephyr/sys.h:46:20:
error: conflicting types for ‘metal_wait_usec’; have ‘void(uint32_t)’
   46 | static inline void metal_wait_usec(uint32_t usec_to_wait)
      |                    ^~~~~~~~~~~~~~~
libmetal/lib/include/metal/processor/hosted/cpu.h:19:9:
note: previous implicit declaration of ‘metal_wait_usec’ with
type ‘void(uint32_t)’ {aka ‘void(unsigned int)’}
   19 |         metal_wait_usec(10);
      |         ^~~~~~~~~~~~~~~