### PR TITLE
io: fix buffer overflow in metal_sys_io_mem_map()

### DIFF
--- a/lib/system/freertos/io.c
+++ b/lib/system/freertos/io.c
@@ -22,7 +22,7 @@ void metal_sys_io_mem_map(struct metal_io_region *io)
 	if (psize) {
 		if (psize >> io->page_shift)
 			psize = (size_t)1 << io->page_shift;
-		for (p = 0; p <= (io->size >> io->page_shift); p++) {
+		for (p = 0; p <= ((io->size - 1) >> io->page_shift); p++) {
 			metal_machine_io_mem_map(va, io->physmap[p],
 						 psize, io->mem_flags);
 			va += psize;

--- a/lib/system/generic/io.c
+++ b/lib/system/generic/io.c
@@ -22,7 +22,7 @@ void metal_sys_io_mem_map(struct metal_io_region *io)
 	if (psize) {
 		if (psize >> io->page_shift)
 			psize = (size_t)1 << io->page_shift;
-		for (p = 0; p <= (io->size >> io->page_shift); p++) {
+		for (p = 0; p <= ((io->size - 1) >> io->page_shift); p++) {
 			metal_machine_io_mem_map(va, io->physmap[p],
 						 psize, io->mem_flags);
 			va += psize;


### PR DESCRIPTION
In metal_sys_io_mem_map() if the I/O region size
is a multiple of (1<<page_shift) will result in a
buffer overflow in the for loop.

Therefore, adjust loop termination condition to
prevent accessing an out-of-bounds page.