### PR TITLE
cmake: update cmake minimum support to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
-if (POLICY CMP0048)
-  cmake_policy(SET CMP0048 NEW)
-endif()
-
-if (POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
+cmake_minimum_required (VERSION 3.16)
 
 set (LIBMETAL_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 


### PR DESCRIPTION
We currently support an old version of CMake (3.0.2) that was released in 2018.

This requires adding specific policies to support the evolution to the latest versions of Zephyr.

Update the minimum version to 3.16. The reason for this version is to support environments such as Debian Bullseye that are still in LTS state.

By updating to CMake 3.16 as the minimum version, we can also clean up the following policy add-ons:
- CMP0048 added in CMake v3.0
- CMP0053 added in CMake v3.1
- CMP0077 added in CMake v3.13