### PR TITLE
Doxygen: Generate tag and xml

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1848,7 +1848,7 @@ MAN_LINKS              = NO
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
-GENERATE_XML           = NO
+GENERATE_XML           = YES
 
 # The XML_OUTPUT tag is used to specify where the XML pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2045,7 +2045,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = libmetal.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be


### PR DESCRIPTION
Not sure which branch/tag this pull request should be to, so adjust as required.

In order to be able to embed (through breathe) and link to (through doxylink) doxygen content in this repository through the RST (restructured text) files of https://github.com/OpenAMP/openamp-docs the doxygen generation needs to enable xml and tag file generation.

Once this pull request is in place, openamp-docs git submodule needs to be bumped to make the change effective for the document generation.
