### PR TITLE
CI: Update zephyr known good versions

### DIFF
--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -3,8 +3,8 @@
 readonly TARGET="$1"
 
 # Known good version for PR testing
-ZEPHYR_SDK_VERSION=v0.16.8
-ZEPHYR_VERSION=v3.7.0
+ZEPHYR_SDK_VERSION=v0.17.0
+ZEPHYR_VERSION=v4.1.0
 
 ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 ZEPHYR_SDK_API_FOLDER=https://api.github.com/repos/zephyrproject-rtos/sdk-ng/releases


### PR DESCRIPTION
Bump to Zephyr 4.1 and SDK 0.17.