### PR TITLE
system: linux: include missing headers

### DIFF
--- a/test/system/linux/threads.c
+++ b/test/system/linux/threads.c
@@ -8,6 +8,9 @@
 #include <metal/utilities.h>
 #include "metal-test.h"
 
+#include <string.h>
+#include <pthread.h>
+
 int metal_run(int threads, metal_thread_t child, void *arg)
 {
 	pthread_t tids[threads];


### PR DESCRIPTION
Do not rely on indirect includes since they may not be present on some systems.