### PR TITLE
Add cross-platform tests for libmetal

### DIFF
--- a/test/system/cross-platform/Makefile
+++ b/test/system/cross-platform/Makefile
@@ -1,0 +1,25 @@
+SRC_DIR := src
+OUT_DIR := out
+TEST_SRC := $(SRC_DIR)/test_all.c
+TEST_OUT := $(OUT_DIR)/test_all.out
+
+CC := gcc
+CFLAGS := -g -I ../../../install/usr/local/include
+LDFLAGS := -L ../../../install/usr/local/lib -lmetal
+
+# Default target: build test_all.c
+all: $(TEST_OUT)
+
+# Rule to build test_all.c into out/test_all.out
+$(TEST_OUT): $(TEST_SRC) | $(OUT_DIR)
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+# Ensure output directory exists
+$(OUT_DIR):
+	mkdir -p $(OUT_DIR)
+
+# Clean build outputs
+.PHONY: clean
+clean:
+	rm -rf $(OUT_DIR)
+

--- a/test/system/cross-platform/src/alloc.c
+++ b/test/system/cross-platform/src/alloc.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		alloc.c
+ * @brief		Cross-platform tests for alloc interface
+ */
+
+int test_alloc(void)
+{
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+	int *mem_ptr;
+
+	metal_init(&metal_param);
+	metal_set_log_handler(metal_default_log_handler);
+	metal_set_log_level(METAL_LOG_ERROR);
+
+	mem_ptr = metal_allocate_memory(16);
+	if (!mem_ptr) {
+		metal_log(METAL_LOG_ERROR, "metal_allocate_memory(16) returned null\n");
+		return 1;
+	}
+
+	metal_log(METAL_LOG_DEBUG,
+		  "Writing -2147483648, -1, 0, 2147483647 to allocated memory\n");
+
+	mem_ptr[0] = -2147483648;
+	mem_ptr[1] = -1;
+	mem_ptr[2] = 0;
+	mem_ptr[3] = 2147483647;
+
+	if (mem_ptr[0] != -2147483648 || mem_ptr[1] != -1 ||
+	    mem_ptr[2] != 0 || mem_ptr[3] != 2147483647) {
+
+		metal_log(METAL_LOG_ERROR,
+			  "Allocated memory has values %d, %d, %d, %d instead of -2147483648, -1 , 0, 2147483647\n",
+			  mem_ptr[0], mem_ptr[1], mem_ptr[2], mem_ptr[3]);
+		return 1;
+	}
+
+	metal_free_memory(mem_ptr);
+
+	metal_finish();
+	return 0;
+}

--- a/test/system/cross-platform/src/assert.c
+++ b/test/system/cross-platform/src/assert.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		assert.c
+ * @brief		Cross-platform tests for assert interface
+ */
+
+int test_assert(void)
+{
+	metal_assert(1);
+
+	return 0;
+}

--- a/test/system/cross-platform/src/cache.c
+++ b/test/system/cross-platform/src/cache.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		cache.c
+ * @brief		Cross-platform tests for cache interface
+ */
+
+int test_cache(void)
+{
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+
+	metal_init(&metal_param);
+	metal_set_log_handler(metal_default_log_handler);
+	metal_set_log_level(METAL_LOG_ERROR);
+
+	metal_log(METAL_LOG_DEBUG, "Flushing entire DCache\n");
+	metal_cache_flush(NULL, 0);
+
+	metal_log(METAL_LOG_DEBUG, "Invalidating entire DCache\n");
+	metal_cache_invalidate(NULL, 0);
+
+	metal_finish();
+	return 0;
+}

--- a/test/system/cross-platform/src/config.c
+++ b/test/system/cross-platform/src/config.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		config.c
+ * @brief		Cross-platform tests for config interface
+ */
+
+int test_config(void)
+{
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+
+	metal_init(&metal_param);
+	metal_set_log_handler(metal_default_log_handler);
+	metal_set_log_level(METAL_LOG_INFO);
+
+	metal_log(METAL_LOG_INFO,
+		  "Metal version is: %d.%d.%d\n",
+		  METAL_VER_MAJOR, METAL_VER_MINOR, METAL_VER_PATCH);
+
+	metal_log(METAL_LOG_INFO,
+		  "In string form: %s\n",
+		  METAL_VER);
+
+	metal_log(METAL_LOG_INFO,
+		  "Metal system identifies as: %s\n",
+		  METAL_SYSTEM);
+
+	metal_log(METAL_LOG_INFO,
+		  "Metal processor identifies as: %s\n",
+		  METAL_PROCESSOR);
+
+	metal_log(METAL_LOG_INFO,
+		  "Metal machine identifies as: %s\n",
+		  METAL_MACHINE);
+
+	metal_finish();
+	return 0;
+}

--- a/test/system/cross-platform/src/cpu.c
+++ b/test/system/cross-platform/src/cpu.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		cpu.c
+ * @brief		Cross-platform tests for cpu interface
+ */
+
+int test_cpu(void)
+{
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+
+	metal_init(&metal_param);
+	metal_set_log_handler(metal_default_log_handler);
+	metal_set_log_level(METAL_LOG_ERROR);
+
+	metal_log(METAL_LOG_DEBUG,
+		  "CPU Yielding\n");
+	metal_cpu_yield();
+
+	metal_finish();
+	return 0;
+}

--- a/test/system/cross-platform/src/init.c
+++ b/test/system/cross-platform/src/init.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		init.c
+ * @brief		Cross-platform tests for init interface
+ */
+
+int test_init(void)
+{
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+	int init_ret;
+
+	init_ret = metal_init(&metal_param);
+	metal_set_log_handler(metal_default_log_handler);
+	metal_set_log_level(METAL_LOG_ERROR);
+
+	if (init_ret)
+		metal_log(METAL_LOG_ERROR,
+			  "init_ret returned %d\n",
+			  init_ret);
+
+	metal_finish();
+	return init_ret;
+}

--- a/test/system/cross-platform/src/log.c
+++ b/test/system/cross-platform/src/log.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		log.c
+ * @brief		Cross-platform tests for log interface
+ */
+
+int test_log(void)
+{
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+
+	metal_init(&metal_param);
+
+	metal_set_log_handler(metal_default_log_handler);
+	metal_set_log_level(METAL_LOG_WARNING);
+
+	metal_log(METAL_LOG_DEBUG,
+		  "Metal log level is: %d\n",
+		  metal_get_log_level());
+
+	metal_log(METAL_LOG_EMERGENCY, "Emergency log example\n");
+	metal_log(METAL_LOG_ALERT, "Alert log example\n");
+	metal_log(METAL_LOG_CRITICAL, "Critical log example\n");
+	metal_log(METAL_LOG_ERROR, "Error log example\n");
+	metal_log(METAL_LOG_WARNING, "Warning log example\n");
+	metal_log(METAL_LOG_NOTICE, "Notice log example\n");
+	metal_log(METAL_LOG_INFO, "Info log example\n");
+	metal_log(METAL_LOG_DEBUG, "Debug log example\n");
+
+	metal_finish();
+	return 0;
+}

--- a/test/system/cross-platform/src/mutex.c
+++ b/test/system/cross-platform/src/mutex.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		mutex.c
+ * @brief		Cross-platform tests for mutex interface, pthread based
+ */
+
+#define ARRAY_SIZE 100
+
+int sum_m;
+metal_mutex_t mut;
+
+struct args_m  {
+	int *arr;
+	int len1;
+	int len2;
+};
+
+void *array_sum_m(void *a)
+{
+	struct args_m *arg = (struct args_m *)a;
+	int len1 = arg->len1;
+	int len2 = arg->len2;
+	int mid = (len2 - len1) / 2;
+
+	for (int i = 0; i <= mid; i++) {
+		metal_mutex_acquire(&mut);
+
+		if ((len2 - len1 + 1) % 2 && i == mid) {
+			sum_m += arg->arr[len1 + i];
+			metal_log(METAL_LOG_DEBUG,
+				  "Sum is now %d from adding %d\n",
+				  sum_m, arg->arr[len1 + i]);
+			metal_mutex_release(&mut);
+			break;
+		}
+		sum_m += arg->arr[len1 + i] + arg->arr[len2 - i];
+		metal_log(METAL_LOG_DEBUG,
+			  "Sum is now %d from adding %d,%d\n",
+			  sum_m, arg->arr[len1 + i], arg->arr[len2 - i]);
+		metal_mutex_release(&mut);
+		usleep(1);
+	}
+
+	return NULL;
+}
+
+int test_mutex(void)
+{
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+	int array[ARRAY_SIZE];
+
+	for (int i = 0; i < ARRAY_SIZE; i++) {
+		array[i] = i + 1;
+	}
+
+	int length = sizeof(array) / sizeof(int);
+	struct args_m args1 = {array, length / 2, length - 1};
+	struct args_m args2 = {array, 0, length / 2 - 1};
+	pthread_t tid1, tid2;
+
+	metal_init(&metal_param);
+	metal_mutex_init(&mut);
+
+	metal_set_log_handler(metal_default_log_handler);
+	metal_set_log_level(METAL_LOG_ERROR);
+
+	pthread_create(&tid1,
+		       NULL,
+		       array_sum_m,
+		       &args1);
+
+	pthread_create(&tid2,
+		       NULL,
+		       array_sum_m,
+		       &args2);
+
+	pthread_join(tid1, NULL);
+	pthread_join(tid2, NULL);
+
+	metal_log(METAL_LOG_INFO,
+		  "Sum = %d returned for array with values [%d, %d]\n",
+		  sum_m, array[0], array[ARRAY_SIZE - 1]);
+
+	metal_mutex_deinit(&mut);
+	metal_finish();
+
+	return 0;
+}

--- a/test/system/cross-platform/src/shmem.c
+++ b/test/system/cross-platform/src/shmem.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		shmem.c
+ * @brief		Cross-platform tests for shmem interface
+ */
+
+int test_shmem(void)
+{
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+	struct metal_io_region **res;
+	int ret = 0;
+
+	metal_init(&metal_param);
+	metal_set_log_handler(metal_default_log_handler);
+	metal_set_log_level(METAL_LOG_ERROR);
+
+	ret = metal_shmem_open("/foo", 128, res);
+	if (ret < 0) {
+		metal_log(METAL_LOG_ERROR,
+			  "metal_shmem_open failed with code: %d\n",
+			  ret);
+		return ret;
+	}
+
+	metal_finish();
+	return 0;
+}

--- a/test/system/cross-platform/src/sleep.c
+++ b/test/system/cross-platform/src/sleep.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		sleep.c
+ * @brief		Cross-platform tests for sleep interface
+ */
+
+#define SLEEP_SECONDS 3
+#define SLEEP_USECONDS (SLEEP_SECONDS * 1000000)
+
+int test_sleep(void)
+{
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+	int ret = 0;
+	int tmp_time = 0;
+
+	metal_init(&metal_param);
+	metal_set_log_handler(metal_default_log_handler);
+	metal_set_log_level(METAL_LOG_ERROR);
+
+	metal_log(METAL_LOG_INFO,
+		  "Time is currently %d, sleeping for %u seconds\n",
+		  time(0), SLEEP_SECONDS);
+
+	tmp_time = time(0);
+
+	ret = metal_sleep_usec(SLEEP_USECONDS);
+	if (ret)
+		metal_log(METAL_LOG_ERROR,
+			  "Function metal_sleep_usec returned %d\n",
+			  ret);
+
+	metal_log(METAL_LOG_INFO,
+		  "Time is now %d\n",
+		  time(0));
+	metal_finish();
+	return 0;
+}

--- a/test/system/cross-platform/src/spinlock.c
+++ b/test/system/cross-platform/src/spinlock.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		spinlock.c
+ * @brief		Cross-platform tests for spinlock interface, pthread based
+ */
+
+#define ARRAY_SIZE 100
+
+int sum_s;
+struct metal_spinlock slock;
+
+struct args  {
+	int *arr;
+	int len1;
+	int len2;
+};
+
+void *array_sum_s(void *a)
+{
+	struct args *arg = (struct args *)a;
+	int len1 = arg->len1;
+	int len2 = arg->len2;
+	int mid = (len2 - len1) / 2;
+
+	for (int i = 0; i <= mid; i++) {
+		metal_spinlock_acquire(&slock);
+
+		if ((len2 - len1 + 1) % 2 && i == mid) {
+			sum_s += arg->arr[len1 + i];
+			metal_log(METAL_LOG_DEBUG,
+				  "Sum is now %d from adding %d\n",
+				  sum_s, arg->arr[len1 + i]);
+			metal_spinlock_release(&slock);
+			break;
+		}
+		sum_s += arg->arr[len1 + i] + arg->arr[len2 - i];
+		metal_log(METAL_LOG_DEBUG,
+			  "Sum is now %d from adding %d,%d\n",
+			  sum_s, arg->arr[len1 + i], arg->arr[len2 - i]);
+		metal_spinlock_release(&slock);
+		usleep(1);
+	}
+
+	return NULL;
+}
+
+int test_spinlock(void)
+{
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+	int array[ARRAY_SIZE];
+
+	for (int i = 0; i < ARRAY_SIZE; i++) {
+		array[i] = i + 1;
+	}
+
+	int length = sizeof(array) / sizeof(int);
+	struct args args1 = {array, length / 2, length - 1};
+	struct args args2 = {array, 0, length / 2 - 1};
+	pthread_t tid1, tid2;
+
+	metal_init(&metal_param);
+	metal_spinlock_init(&slock);
+
+	metal_set_log_handler(metal_default_log_handler);
+	metal_set_log_level(METAL_LOG_ERROR);
+
+	pthread_create(&tid1,
+		       NULL,
+		       array_sum_s,
+		       &args1);
+
+	pthread_create(&tid2,
+		       NULL,
+		       array_sum_s,
+		       &args2);
+
+	pthread_join(tid1, NULL);
+	pthread_join(tid2, NULL);
+
+	metal_log(METAL_LOG_INFO,
+		  "Sum = %d returned for array with values [%d, %d]\n",
+		  sum_s, array[0], array[ARRAY_SIZE - 1]);
+
+	metal_finish();
+	return 0;
+}

--- a/test/system/cross-platform/src/test_all.c
+++ b/test/system/cross-platform/src/test_all.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		test_all.c
+ * @brief		Main cross-platform testing execution and debug printing
+ */
+
+#include "test_all.h"
+
+int main(int argc, char **argv)
+{
+	int i;
+	char pass[] = "\033[0;32m [PASS] \033[0m";
+	char fail[] = "\033[0;31m [FAIL] \033[0m";
+
+	for (i = 0; i < NUM_TESTS; i++) {
+		printf("------%s------\n", tests[i].name);
+		tests[i].ret = tests[i].test();
+	}
+	for (i = 0; i < NUM_TESTS; i++) {
+		if (tests[i].ret == 0)
+			printf("%-12s %s\n", tests[i].name, pass);
+		else
+			printf("%-12s %s (code %d)\n", tests[i].name, fail, tests[i].ret);
+	}
+	return 0;
+}

--- a/test/system/cross-platform/src/test_all.h
+++ b/test/system/cross-platform/src/test_all.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		test_all.h
+ * @brief		Includes, defines and testing suite structs for test_all.c
+ */
+
+#include <stdio.h>
+#include <pthread.h>
+#include <metal/alloc.h>
+#include <metal/assert.h>
+#include <metal/atomic.h>
+#include <metal/cache.h>
+#include <metal/config.h>
+#include <metal/cpu.h>
+#include <metal/device.h>
+#include <metal/dma.h>
+#include <metal/irq.h>
+#include <metal/log.h>
+#include <metal/mutex.h>
+#include <metal/shmem.h>
+#include <metal/sleep.h>
+#include <metal/spinlock.h>
+#include <metal/sys.h>
+#include <metal/time.h>
+#include <metal/utilities.h>
+
+#include "alloc.c"
+#include "assert.c"
+#include "cache.c"
+#include "config.c"
+#include "cpu.c"
+#include "init.c"
+#include "log.c"
+#include "mutex.c"
+#include "shmem.c"
+#include "sleep.c"
+#include "spinlock.c"
+#include "time.c"
+#include "utilities.c"
+
+struct test_entry {
+	char name[20];
+	int (*test)(void);
+	int ret;
+};
+
+struct test_entry tests[] = {
+	{"alloc.c",     test_alloc, 0},
+	{"assert.c",    test_assert, 0},
+	{"cache.c",     test_cache, 0},
+	{"config.c",    test_config, 0},
+	{"cpu.c",       test_cpu, 0},
+	{"init.c",      test_init, 0},
+	{"log.c",       test_log, 0},
+	{"mutex.c",     test_mutex, 0},
+	{"shmem.c",     test_shmem, 0},
+	{"sleep.c",     test_sleep, 0},
+	{"spinlock.c",  test_spinlock, 0},
+	{"time.c",      test_time, 0},
+	{"utilities.c", test_utilities, 0}
+};
+
+#define NUM_TESTS (sizeof(tests) / sizeof(tests[0]))

--- a/test/system/cross-platform/src/time.c
+++ b/test/system/cross-platform/src/time.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		time.c
+ * @brief		Cross-platform tests for time interface
+ */
+
+#define SLEEP_SECONDS 3
+#define SLEEP_USECONDS (SLEEP_SECONDS * 1000000)
+
+int test_time(void)
+{
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+	int ret = 0;
+	unsigned long long tmp_time = 0;
+
+	metal_init(&metal_param);
+	metal_set_log_handler(metal_default_log_handler);
+	metal_set_log_level(METAL_LOG_ERROR);
+
+	metal_log(METAL_LOG_INFO,
+		  "Time is currently %ulld, sleeping for %u seconds\n",
+		  metal_get_timestamp(), SLEEP_SECONDS);
+
+	tmp_time = metal_get_timestamp();
+
+	ret = metal_sleep_usec(SLEEP_USECONDS);
+
+	if (ret) {
+		metal_log(METAL_LOG_ERROR,
+			  "Function metal_sleep_usec returned %d\n",
+			  ret);
+		return 1;
+	}
+
+	metal_log(METAL_LOG_DEBUG,
+		  "Time is now %ulld\n",
+		  metal_get_timestamp());
+	metal_finish();
+	return 0;
+}

--- a/test/system/cross-platform/src/utilities.c
+++ b/test/system/cross-platform/src/utilities.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025, CARV ICS FORTH.
+ *
+ * SPDX-License-Identifier:    BSD-3-Clause
+ */
+
+/*
+ * @file		utilities.c
+ * @brief		Cross-platform tests for utilities interface
+ */
+
+struct example {
+	int num;
+	char c[4];
+	int *ptr;
+};
+
+int test_utilities(void)
+{
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+	int array[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+	char c_array[7] = { 'a', 'b', 'c', 'd', 'e', 'f', 'g' };
+	int error = 0;
+
+	metal_init(&metal_param);
+	metal_set_log_handler(metal_default_log_handler);
+	metal_set_log_level(METAL_LOG_ERROR);
+
+	if (MB != 1048576 || GB != 1073741824) {
+		error = 1;
+		metal_log(METAL_LOG_ERROR,
+			  "1 MiB is %ld instead of 1048576 and 1 GiB is %ld instead of 1073741824\n",
+			  MB, GB);
+	}
+	if (metal_dim(array) != 10) {
+		error = 2;
+		metal_log(METAL_LOG_ERROR,
+			  "Array has %d instead of 10 elements\n",
+			  metal_dim(array));
+	}
+	if (metal_dim(c_array) != 7) {
+		error = 3;
+		metal_log(METAL_LOG_ERROR,
+			  "Character array has %d instead of 7 elements\n",
+			  metal_dim(c_array));
+	}
+	if (metal_min(10, 4) != 4 || metal_max(198, 2) != 198) {
+		error = 4;
+		metal_log(METAL_LOG_ERROR,
+			  "Minimum between 10 and 4 is %d instead of 4 and maximum between 198 and 2 is %d instead of 198\n",
+			  metal_min(10, 4), metal_max(198, 2));
+	}
+	if (metal_min(-10, -4) != -10 || metal_max(-198, -2) != -2) {
+		error = 5;
+		metal_log(METAL_LOG_ERROR,
+			  "Minimum between -10 and -4 is %d instead of -10 and maximum between -198 and -2 is %d instead of -2\n",
+			  metal_min(-10, -4), metal_max(-198, -2));
+	}
+	if (metal_align_down(10, 4) != 8 || metal_align_up(10, 4) != 12) {
+		error = 6;
+		metal_log(METAL_LOG_ERROR,
+			  "10 aligned down to ^4 is %d instead of 8, up to ^4 is %d instead of 12\n",
+			  metal_align_down(10, 4), metal_align_up(10, 4));
+	}
+	if (metal_div_round_down(10, 3) != 3 || metal_div_round_up(10, 3) != 4) {
+		error = 7;
+		metal_log(METAL_LOG_ERROR,
+			  "10 divided by 3 rounded down is %d instead of 3 and rounded up is %d instead of 4\n",
+			  metal_div_round_down(10, 3), metal_div_round_up(10, 3));
+	}
+	if (metal_div_round_down(-10, 3) != -4 || metal_div_round_up(-10, 3) != -3) {
+		error = 8;
+		metal_log(METAL_LOG_ERROR,
+			  "-10 divided by 3 rounded down is %d instead of -4 and rounded up is %d instead of -3\n",
+			  metal_div_round_down(-10, 3), metal_div_round_up(-10, 3));
+	}
+	if (metal_offset_of(struct example, ptr) != 8) {
+		error = 9;
+		metal_log(METAL_LOG_ERROR,
+			  "%d\n", metal_offset_of(struct example, ptr));
+	}
+	metal_finish();
+	return error;
+}


### PR DESCRIPTION
To-be-expanded suite of tests for libmetal using system-agnostic interfaces instead of system specific tests.

There's more tests coming to expand the suite to other interfaces the library provides for completeness.
As much as possible tests isolate their libmetal usage to the filename of the interface they're testing.
When unavoidable, as is the case with init, an extra test is provided testing just that interface to help narrow down any issues.

Known issues:
mutex and shmem testing are pthread based, this will be changed to metal_run in a followup patch.
Interfaces: device, irq, threads, atomics are missing and will also be added later if there's interest in this.

As such this directory doesn't yet tamper with any pre-existing files and uses a simple Makefile for building, after libmetal is built.