### PR TITLE
add public header files for to metal-shared/static CMake targets

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -89,6 +89,7 @@ else (WITH_ZEPHYR)
       VERSION           "${PROJECT_VERSION}"
       SOVERSION         "${PROJECT_VERSION_MAJOR}"
     )
+    target_include_directories (${_lib} PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)
   endif (WITH_SHARED_LIB)
 
   # Build a static library if so configured.
@@ -100,6 +101,7 @@ else (WITH_ZEPHYR)
     set_target_properties (${_lib} PROPERTIES
       OUTPUT_NAME       "${PROJECT_NAME}"
     )
+    target_include_directories (${_lib} PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)
   endif (WITH_STATIC_LIB)
 endif (WITH_ZEPHYR)
 


### PR DESCRIPTION
For consumers who don't want to install libmetal it's more convenient to use the CMake targets metal-static or metal-shared. However, they currently don't bring the necessary include directories (In contrast to the Zephyr version where the include directories are already exported via `zephyr_include_directories(...)`)