### PR TITLE
lib: system: linux: Remove redundant memory validness check

### DIFF
--- a/lib/system/linux/device.c
+++ b/lib/system/linux/device.c
@@ -440,12 +440,6 @@ static int metal_linux_dev_open(struct metal_bus *bus,
 		if (!ldrv->sdrv || !ldrv->dev_open)
 			continue;
 
-		/* Allocate a linux device if we haven't already. */
-		if (!ldev)
-			ldev = malloc(sizeof(*ldev));
-		if (!ldev)
-			return -ENOMEM;
-
 		/* Reset device data. */
 		memset(ldev, 0, sizeof(*ldev));
 		strncpy(ldev->dev_name, dev_name, sizeof(ldev->dev_name) - 1);


### PR DESCRIPTION
In the function prologue, "ldev" has already been assigned a malloc'd address, and a check has also been performed.  Remove this redundant pointer validness check during each iteration. The second check was also inherently misplaced because it was not enclosed in the malloc if-branch.