### PR TITLE
lib: system: linux: Remove redundant malloc'd addr release check

### DIFF
--- a/lib/system/linux/device.c
+++ b/lib/system/linux/device.c
@@ -467,8 +467,7 @@ static int metal_linux_dev_open(struct metal_bus *bus,
 		return 0;
 	}
 
-	if (ldev)
-		free(ldev);
+	free(ldev);
 
 	return -ENODEV;
 }


### PR DESCRIPTION
As the code path suggests, the pointer, ldev, at this point, can be free'd directly w/o a check.  Remove the redundant check.