### PR TITLE
libmetal/nuttx: Update function prototype changes

### DIFF
--- a/lib/system/nuttx/time.c
+++ b/lib/system/nuttx/time.c
@@ -14,14 +14,13 @@
 
 unsigned long long metal_get_timestamp(void)
 {
-	unsigned long long t = 0;
+	unsigned long long t;
 	struct timespec tp;
-	int r;
 
-	r = clock_systime_timespec(&tp);
-	if (!r) {
-		t = (unsigned long long)tp.tv_sec * NSEC_PER_SEC;
-		t += tp.tv_nsec;
-	}
+	clock_systime_timespec(&tp);
+
+	t = (unsigned long long)tp.tv_sec * NSEC_PER_SEC;
+	t += tp.tv_nsec;
+
 	return t;
 }


### PR DESCRIPTION
libmetal/nuttx: Update function prototype changes

clock_systime_timespec() always returns 0, so there is no need to
check the return value in the caller code, let us remove the return
value directly.

From:
`        int clock_systime_timespec(FAR struct timespec *ts)`
To:
`        void clock_systime_timespec(FAR struct timespec *ts)`

Fix build break:

```
libmetal/lib/system/nuttx/time.c: In function ‘metal_get_timestamp’:
libmetal/lib/system/nuttx/time.c:21:11: error: void value not ignored as it ought to be
   21 |         r = clock_systime_timespec(&tp);
      |           ^
make[1]: *** [Makefile:46: libmetal/lib/system/nuttx/time.o] Error 1
```

nuttx kernel pull request:
https://github.com/apache/nuttx/pull/17104

Signed-off-by: chao an <anchao.archer@bytedance.com>
