### PR TITLE
[Fix for release] lib: system: re-enable the support of the template machine

### DIFF
--- a/lib/system/freertos/sys.h
+++ b/lib/system/freertos/sys.h
@@ -20,6 +20,7 @@
 #include <metal/errno.h>
 #include <metal/cpu.h>
 
+#include "./@PROJECT_MACHINE@/sys.h"
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lib/system/freertos/template/CMakeLists.txt
+++ b/lib/system/freertos/template/CMakeLists.txt
@@ -1,0 +1,4 @@
+collect (PROJECT_LIB_HEADERS sys.h)
+
+collect (PROJECT_LIB_SOURCES sys.c)
+

--- a/lib/system/freertos/template/sys.c
+++ b/lib/system/freertos/template/sys.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2018, Linaro Inc. and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	freertos/template/sys.c
+ * @brief	machine specific system primitives implementation.
+ */
+
+#include <metal/io.h>
+#include <metal/sys.h>
+#include <metal/utilities.h>
+#include <stdint.h>
+
+void sys_irq_restore_enable(unsigned int flags)
+{
+	metal_unused(flags);
+	/* Add implementation here */
+}
+
+unsigned int sys_irq_save_disable(void)
+{
+	return 0;
+	/* Add implementation here */
+}
+
+void sys_irq_enable(unsigned int vector)
+{
+	metal_unused(vector);
+
+	/* Add implementation here */
+}
+
+void sys_irq_disable(unsigned int vector)
+{
+	metal_unused(vector);
+
+	/* Add implementation here */
+}
+
+void metal_machine_cache_flush(void *addr, unsigned int len)
+{
+	metal_unused(addr);
+	metal_unused(len);
+
+	/* Add implementation here */
+}
+
+void metal_machine_cache_invalidate(void *addr, unsigned int len)
+{
+	metal_unused(addr);
+	metal_unused(len);
+
+	/* Add implementation here */
+}
+
+void metal_generic_default_poll(void)
+{
+	/* Add implementation here */
+}
+
+void *metal_machine_io_mem_map(void *va, metal_phys_addr_t pa,
+			       size_t size, unsigned int flags)
+{
+	metal_unused(pa);
+	metal_unused(size);
+	metal_unused(flags);
+
+	/* Add implementation here */
+
+	return va;
+}

--- a/lib/system/freertos/template/sys.h
+++ b/lib/system/freertos/template/sys.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018, Linaro Inc. and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	freertos/template/sys.h
+ * @brief	freertos template system primitives for libmetal.
+ */
+
+#ifndef __METAL_FREERTOS_SYS__H__
+#error "Include metal/sys.h instead of metal/freertos/@PROJECT_MACHINE@/sys.h"
+#endif
+
+#ifndef __METAL_FREERTOS_TEMPLATE_SYS__H__
+#define __METAL_FREERTOS_TEMPLATE_SYS__H__
+
+#include <metal/cpu.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define metal_yield() metal_cpu_yield()
+
+#ifdef METAL_INTERNAL
+
+void sys_irq_enable(unsigned int vector);
+
+void sys_irq_disable(unsigned int vector);
+
+#endif /* METAL_INTERNAL */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_FREERTOS_SYS__H__ */

--- a/lib/system/freertos/xlnx/CMakeLists.txt
+++ b/lib/system/freertos/xlnx/CMakeLists.txt
@@ -1,0 +1,5 @@
+collect (PROJECT_LIB_HEADERS sys.h)
+
+collect (PROJECT_LIB_SOURCES irq.c)
+collect (PROJECT_LIB_SOURCES sys.c)
+

--- a/lib/system/generic/sys.h
+++ b/lib/system/generic/sys.h
@@ -24,6 +24,7 @@
 #include <stdarg.h>
 #include <string.h>
 
+#include "./@PROJECT_MACHINE@/sys.h"
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lib/system/generic/template/CMakeLists.txt
+++ b/lib/system/generic/template/CMakeLists.txt
@@ -1,0 +1,3 @@
+collect (PROJECT_LIB_HEADERS sys.h)
+
+collect (PROJECT_LIB_SOURCES sys.c)

--- a/lib/system/generic/template/sys.c
+++ b/lib/system/generic/template/sys.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2018, Linaro Inc. and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	generic/template/sys.c
+ * @brief	machine specific system primitives implementation.
+ */
+
+#include <metal/io.h>
+#include <metal/sys.h>
+#include <metal/utilities.h>
+#include <stdint.h>
+
+void sys_irq_restore_enable(unsigned int flags)
+{
+	metal_unused(flags);
+	/* Add implementation here */
+}
+
+unsigned int sys_irq_save_disable(void)
+{
+	return 0;
+	/* Add implementation here */
+}
+
+void sys_irq_enable(unsigned int vector)
+{
+	metal_unused(vector);
+
+	/* Add implementation here */
+}
+
+void sys_irq_disable(unsigned int vector)
+{
+	metal_unused(vector);
+
+	/* Add implementation here */
+}
+
+void metal_machine_cache_flush(void *addr, unsigned int len)
+{
+	metal_unused(addr);
+	metal_unused(len);
+
+	/* Add implementation here */
+}
+
+void metal_machine_cache_invalidate(void *addr, unsigned int len)
+{
+	metal_unused(addr);
+	metal_unused(len);
+
+	/* Add implementation here */
+}
+
+void metal_generic_default_poll(void)
+{
+	/* Add implementation here */
+}
+
+void *metal_machine_io_mem_map(void *va, metal_phys_addr_t pa,
+			       size_t size, unsigned int flags)
+{
+	metal_unused(pa);
+	metal_unused(size);
+	metal_unused(flags);
+
+	/* Add implementation here */
+
+	return va;
+}

--- a/lib/system/generic/template/sys.h
+++ b/lib/system/generic/template/sys.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018, Linaro Inc. and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	generic/template/sys.h
+ * @brief	generic template system primitives for libmetal.
+ */
+
+#ifndef __METAL_GENERIC_SYS__H__
+#error "Include metal/sys.h instead of metal/generic/@PROJECT_MACHINE@/sys.h"
+#endif
+
+#ifndef __METAL_GENERIC_TEMPLATE_SYS__H__
+#define __METAL_GENERIC_TEMPLATE_SYS__H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef METAL_INTERNAL
+
+void sys_irq_enable(unsigned int vector);
+
+void sys_irq_disable(unsigned int vector);
+
+#endif /* METAL_INTERNAL */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_GENERIC_TEMPLATE_SYS__H__ */


### PR DESCRIPTION
The template machine is used in:
cmake/platforms/template-generic.cmake
cmake/platforms/template-freertos.cmake

This reverts a part of commit:
16493b179fb4 ("lib: system: remove xlnx BSP specific code")