### PR TITLE
cmake: Do not propagate compilation options to the main project

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -71,7 +71,7 @@ option (WITH_FUNC_LINE_LOG "Log with function name, line number prefix" OFF)
 
 option (WITH_DOC "Build with documentation" ON)
 
-set_property (GLOBAL PROPERTY "PROJECT_EC_FLAGS" -Wall -Werror -Wextra)
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -Wextra")
 
 if (NOT DEFINED PROJECT_VENDOR)
 set (PROJECT_VENDOR "none")

--- a/lib/system/zephyr/init.c
+++ b/lib/system/zephyr/init.c
@@ -17,6 +17,8 @@ struct metal_state _metal;
 
 int metal_sys_init(const struct metal_init_params *params)
 {
+	(void)params;
+
 	metal_bus_register(&metal_generic_bus);
 	return 0;
 }

--- a/test/system/zephyr/main.c
+++ b/test/system/zephyr/main.c
@@ -28,7 +28,7 @@ extern void metal_test_add_mutex();
 
 extern void *metal_zephyr_allocate_memory(unsigned int size)
 {
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < sizeof(block)/sizeof(block[0]); i++) {
 		if (!block[i]) {
@@ -45,7 +45,7 @@ extern void *metal_zephyr_allocate_memory(unsigned int size)
 
 extern void metal_zephyr_free_memory(void *ptr)
 {
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < sizeof(block)/sizeof(block[0]); i++) {
 		if (block[i] == ptr) {


### PR DESCRIPTION
When libmetal is included in the main project using add_subdirectory(libmetal), using set_property(GLOBAL ...) propagates properties to the main project. This can cause build errors if warnings are treated as errors.

Remove set_property(GLOBAL ...) calls from libmetal’s CMakeLists. Use only target_compile_options and target properties on libmetal’s own targets. The main project should determine its own compilation options.

fix commit d077e286a437 ("cmake: set PROJECT_EC_FLAGS to be GLOBAL property")