### PR TITLE
Remove toc not included and other sphinx warnings

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2069,12 +2069,6 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2087,15 +2081,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = YES
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -760,6 +760,7 @@ WARN_LOGFILE           =
 
 INPUT = @PROJECT_SOURCE_DIR@/README.md
 INPUT += @PROJECT_SOURCE_DIR@/LICENSE.md
+INPUT += @PROJECT_SOURCE_DIR@/MAINTAINERS.md
 INPUT += @PROJECT_SOURCE_DIR@/lib
 
 # This tag can be used to specify the character encoding of the source files


### PR DESCRIPTION
This pull request (PR) supports openamp-docs PR https://github.com/OpenAMP/openamp-docs/pull/82, whose intent is to better integrate git submodule documentation into openamp readthedocs.
Any markdown (.md) or restructured text (.rst) not included in openamp-docs show up as sphinx documentation warnings "toc not included", so these are either introduced into readthedocs or hidden if not relevant.
Also additional warnings added due to restructuring of some documents are removed also.