### PR TITLE
lib: Fix docs group names

### DIFF
--- a/lib/cache.h
+++ b/lib/cache.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-/** \defgroup cache CACHE Interfaces
+/** \defgroup cache Cache Interfaces
  *  @{
  */
 

--- a/lib/log.h
+++ b/lib/log.h
@@ -16,7 +16,7 @@
 extern "C" {
 #endif
 
-/** \defgroup logging Library Logging Interfaces
+/** \defgroup logging Logging Interfaces
  *  @{
  */
 

--- a/lib/softirq.h
+++ b/lib/softirq.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-/** \defgroup soft irq Interrupt Handling Interfaces
+/** \defgroup softirq Soft Interrupt Handling Interfaces
  *  @{
  */
 

--- a/lib/time.h
+++ b/lib/time.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-/** \defgroup time TIME Interfaces
+/** \defgroup time Time Interfaces
  *  @{
  */
 


### PR DESCRIPTION
These names need to match what is referenced in other parts of the docs or links may not function correctly. This is the case for softirq.h, the rest of these changes are to make the names more uniform, which looks better when listing all doc pages.