### PR TITLE
lib: Avoid mentioning the current filename in compile-time warning

### DIFF
--- a/lib/system/freertos/alloc.h
+++ b/lib/system/freertos/alloc.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_ALLOC__H__
-#error "Include metal/alloc.h instead of metal/freertos/alloc.h"
+#error "Do not include this file directly, include <metal/alloc.h> instead"
 #endif
 
 #ifndef __METAL_FREERTOS_ALLOC__H__

--- a/lib/system/freertos/assert.h
+++ b/lib/system/freertos/assert.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_ASSERT__H__
-#error "Include metal/assert.h instead of metal/freertos/assert.h"
+#error "Do not include this file directly, include <metal/assert.h> instead"
 #endif
 
 #ifndef __METAL_FREERTOS_ASSERT__H__

--- a/lib/system/freertos/cache.h
+++ b/lib/system/freertos/cache.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_CACHE__H__
-#error "Include metal/cache.h instead of metal/freertos/cache.h"
+#error "Do not include this file directly, include <metal/cache.h> instead"
 #endif
 
 #ifndef __METAL_FREERTOS_CACHE__H__

--- a/lib/system/freertos/condition.h
+++ b/lib/system/freertos/condition.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_CONDITION__H__
-#error "Include metal/condition.h instead of metal/freertos/condition.h"
+#error "Do not include this file directly, include <metal/condition.h> instead"
 #endif
 
 #ifndef __METAL_FREERTOS_CONDITION__H__

--- a/lib/system/freertos/io.h
+++ b/lib/system/freertos/io.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_IO__H__
-#error "Include metal/io.h instead of metal/freertos/io.h"
+#error "Do not include this file directly, include <metal/io.h> instead"
 #endif
 
 #ifndef __METAL_FREEROTS_IO__H__

--- a/lib/system/freertos/mutex.h
+++ b/lib/system/freertos/mutex.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_MUTEX__H__
-#error "Include metal/mutex.h instead of metal/freertos/mutex.h"
+#error "Do not include this file directly, include <metal/mutex.h> instead"
 #endif
 
 #ifndef __METAL_FREERTOS_MUTEX__H__

--- a/lib/system/freertos/sleep.h
+++ b/lib/system/freertos/sleep.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_SLEEP__H__
-#error "Include metal/sleep.h instead of metal/freertos/sleep.h"
+#error "Do not include this file directly, include <metal/sleep.h> instead"
 #endif
 
 #ifndef __METAL_FREERTOS_SLEEP__H__

--- a/lib/system/freertos/sys.h
+++ b/lib/system/freertos/sys.h
@@ -11,7 +11,7 @@
  */
 
 #ifndef __METAL_SYS__H__
-#error "Include metal/sys.h instead of metal/freertos/sys.h"
+#error "Do not include this file directly, include <metal/sys.h> instead"
 #endif
 
 #ifndef __METAL_FREERTOS_SYS__H__

--- a/lib/system/generic/alloc.h
+++ b/lib/system/generic/alloc.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_ALLOC__H__
-#error "Include metal/alloc.h instead of metal/generic/alloc.h"
+#error "Do not include this file directly, include <metal/alloc.h> instead"
 #endif
 
 #ifndef __METAL_GENERIC_ALLOC__H__

--- a/lib/system/generic/assert.h
+++ b/lib/system/generic/assert.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_ASSERT__H__
-#error "Include metal/assert.h instead of metal/generic/assert.h"
+#error "Do not include this file directly, include <metal/assert.h> instead"
 #endif
 
 #ifndef __METAL_GENERIC_ASSERT__H__

--- a/lib/system/generic/cache.h
+++ b/lib/system/generic/cache.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_CACHE__H__
-#error "Include metal/cache.h instead of metal/generic/cache.h"
+#error "Do not include this file directly, include <metal/cache.h> instead"
 #endif
 
 #ifndef __METAL_GENERIC_CACHE__H__

--- a/lib/system/generic/condition.h
+++ b/lib/system/generic/condition.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_CONDITION__H__
-#error "Include metal/condition.h instead of metal/generic/condition.h"
+#error "Do not include this file directly, include <metal/condition.h> instead"
 #endif
 
 #ifndef __METAL_GENERIC_CONDITION__H__

--- a/lib/system/generic/io.h
+++ b/lib/system/generic/io.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_IO__H__
-#error "Include metal/io.h instead of metal/generic/io.h"
+#error "Do not include this file directly, include <metal/io.h> instead"
 #endif
 
 #ifndef __METAL_GENERIC_IO__H__

--- a/lib/system/generic/mutex.h
+++ b/lib/system/generic/mutex.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_MUTEX__H__
-#error "Include metal/mutex.h instead of metal/generic/mutex.h"
+#error "Do not include this file directly, include <metal/mutex.h> instead"
 #endif
 
 #ifndef __METAL_GENERIC_MUTEX__H__

--- a/lib/system/generic/sleep.h
+++ b/lib/system/generic/sleep.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_SLEEP__H__
-#error "Include metal/sleep.h instead of metal/generic/sleep.h"
+#error "Do not include this file directly, include <metal/sleep.h> instead"
 #endif
 
 #ifndef __METAL_GENERIC_SLEEP__H__

--- a/lib/system/generic/sys.h
+++ b/lib/system/generic/sys.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_SYS__H__
-#error "Include metal/sys.h instead of metal/generic/sys.h"
+#error "Do not include this file directly, include <metal/sys.h> instead"
 #endif
 
 #ifndef __METAL_GENERIC_SYS__H__

--- a/lib/system/linux/alloc.h
+++ b/lib/system/linux/alloc.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_ALLOC__H__
-#error "Include metal/alloc.h instead of metal/linux/alloc.h"
+#error "Do not include this file directly, include <metal/alloc.h> instead"
 #endif
 
 #ifndef __METAL_LINUX_ALLOC__H__

--- a/lib/system/linux/assert.h
+++ b/lib/system/linux/assert.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_ASSERT__H__
-#error "Include metal/assert.h instead of metal/linux/assert.h"
+#error "Do not include this file directly, include <metal/assert.h> instead"
 #endif
 
 #ifndef __METAL_LINUX_ASSERT__H__

--- a/lib/system/linux/cache.h
+++ b/lib/system/linux/cache.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_CACHE__H__
-#error "Include metal/cache.h instead of metal/linux/cache.h"
+#error "Do not include this file directly, include <metal/cache.h> instead"
 #endif
 
 #ifndef __METAL_LINUX_CACHE__H__

--- a/lib/system/linux/condition.h
+++ b/lib/system/linux/condition.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_CONDITION__H__
-#error "Include metal/condition.h instead of metal/linux/condition.h"
+#error "Do not include this file directly, include <metal/condition.h> instead"
 #endif
 
 #ifndef __METAL_LINUX_CONDITION__H__

--- a/lib/system/linux/io.h
+++ b/lib/system/linux/io.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_IO__H__
-#error "Include metal/io.h instead of metal/linux/io.h"
+#error "Do not include this file directly, include <metal/io.h> instead"
 #endif
 
 #ifndef __METAL_LINUX_IO__H__

--- a/lib/system/linux/irq.h
+++ b/lib/system/linux/irq.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_IRQ__H__
-#error "Include metal/irq.h instead of metal/linux/irq.h"
+#error "Do not include this file directly, include <metal/irq.h> instead"
 #endif
 
 #ifndef __METAL_LINUX_IRQ__H__

--- a/lib/system/linux/mutex.h
+++ b/lib/system/linux/mutex.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_MUTEX__H__
-#error "Include metal/mutex.h instead of metal/linux/mutex.h"
+#error "Do not include this file directly, include <metal/mutex.h> instead"
 #endif
 
 #ifndef __METAL_LINUX_MUTEX__H__

--- a/lib/system/linux/sleep.h
+++ b/lib/system/linux/sleep.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_SLEEP__H__
-#error "Include metal/sleep.h instead of metal/linux/sleep.h"
+#error "Do not include this file directly, include <metal/sleep.h> instead"
 #endif
 
 #ifndef __METAL_LINUX_SLEEP__H__

--- a/lib/system/linux/sys.h
+++ b/lib/system/linux/sys.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_SYS__H__
-#error "Include metal/sys.h instead of metal/linux/sys.h"
+#error "Do not include this file directly, include <metal/sys.h> instead"
 #endif
 
 #ifndef __METAL_LINUX_SYS__H__

--- a/lib/system/nuttx/alloc.h
+++ b/lib/system/nuttx/alloc.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_ALLOC__H__
-#error "Include metal/alloc.h instead of metal/nuttx/alloc.h"
+#error "Do not include this file directly, include <metal/alloc.h> instead"
 #endif
 
 #ifndef __METAL_NUTTX_ALLOC__H__

--- a/lib/system/nuttx/assert.h
+++ b/lib/system/nuttx/assert.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_ASSERT__H__
-#error "Include metal/assert.h instead of metal/nuttx/assert.h"
+#error "Do not include this file directly, include <metal/assert.h> instead"
 #endif
 
 #ifndef __METAL_NUTTX_ASSERT__H__

--- a/lib/system/nuttx/cache.h
+++ b/lib/system/nuttx/cache.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_CACHE__H__
-#error "Include metal/cache.h instead of metal/nuttx/cache.h"
+#error "Do not include this file directly, include <metal/cache.h> instead"
 #endif
 
 #ifndef __METAL_NUTTX_CACHE__H__

--- a/lib/system/nuttx/condition.h
+++ b/lib/system/nuttx/condition.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_CONDITION__H__
-#error "Include metal/condition.h instead of metal/nuttx/condition.h"
+#error "Do not include this file directly, include <metal/condition.h> instead"
 #endif
 
 #ifndef __METAL_NUTTX_CONDITION__H__

--- a/lib/system/nuttx/io.h
+++ b/lib/system/nuttx/io.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_IO__H__
-#error "Include metal/io.h instead of metal/nuttx/io.h"
+#error "Do not include this file directly, include <metal/io.h> instead"
 #endif
 
 #ifndef __METAL_NUTTX_IO__H__

--- a/lib/system/nuttx/irq.h
+++ b/lib/system/nuttx/irq.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_IRQ__H__
-#error "Include metal/irq.h instead of metal/nuttx/irq.h"
+#error "Do not include this file directly, include <metal/irq.h> instead"
 #endif
 
 #ifndef __METAL_NUTTX_IRQ__H__

--- a/lib/system/nuttx/mutex.h
+++ b/lib/system/nuttx/mutex.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_MUTEX__H__
-#error "Include metal/mutex.h instead of metal/nuttx/mutex.h"
+#error "Do not include this file directly, include <metal/mutex.h> instead"
 #endif
 
 #ifndef __METAL_NUTTX_MUTEX__H__

--- a/lib/system/nuttx/sleep.h
+++ b/lib/system/nuttx/sleep.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_SLEEP__H__
-#error "Include metal/sleep.h instead of metal/nuttx/sleep.h"
+#error "Do not include this file directly, include <metal/sleep.h> instead"
 #endif
 
 #ifndef __METAL_NUTTX_SLEEP__H__

--- a/lib/system/nuttx/sys.h
+++ b/lib/system/nuttx/sys.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_SYS__H__
-#error "Include metal/sys.h instead of metal/nuttx/sys.h"
+#error "Do not include this file directly, include <metal/sys.h> instead"
 #endif
 
 #ifndef __METAL_NUTTX_SYS__H__

--- a/lib/system/zephyr/alloc.h
+++ b/lib/system/zephyr/alloc.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_ALLOC__H__
-#error "Include metal/alloc.h instead of metal/zephyr/alloc.h"
+#error "Do not include this file directly, include <metal/alloc.h> instead"
 #endif
 
 #ifndef __METAL_ZEPHYR_ALLOC__H__

--- a/lib/system/zephyr/assert.h
+++ b/lib/system/zephyr/assert.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_ASSERT__H__
-#error "Include metal/assert.h instead of metal/zephyr/assert.h"
+#error "Do not include this file directly, include <metal/assert.h> instead"
 #endif
 
 #ifndef __METAL_ZEPHYR_ASSERT__H__

--- a/lib/system/zephyr/cache.h
+++ b/lib/system/zephyr/cache.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_CACHE__H__
-#error "Include metal/cache.h instead of metal/zephyr/cache.h"
+#error "Do not include this file directly, include <metal/cache.h> instead"
 #endif
 
 #ifndef __METAL_ZEPHYR_CACHE__H__

--- a/lib/system/zephyr/condition.h
+++ b/lib/system/zephyr/condition.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_CONDITION__H__
-#error "Include metal/condition.h instead of metal/generic/condition.h"
+#error "Do not include this file directly, include <metal/condition.h> instead"
 #endif
 
 #ifndef __METAL_ZEPHYR_CONDITION__H__

--- a/lib/system/zephyr/io.h
+++ b/lib/system/zephyr/io.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_IO__H__
-#error "Include metal/io.h instead of metal/zephyr/io.h"
+#error "Do not include this file directly, include <metal/io.h> instead"
 #endif
 
 #ifndef __METAL_ZEPHYR_IO__H__

--- a/lib/system/zephyr/log.h
+++ b/lib/system/zephyr/log.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_METAL_LOG__H__
-#error "Include metal/log.h instead of metal/zephyr/log.h"
+#error "Do not include this file directly, include <metal/log.h> instead"
 #endif
 
 #ifndef __METAL_ZEPHYR_LOG__H__

--- a/lib/system/zephyr/mutex.h
+++ b/lib/system/zephyr/mutex.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_MUTEX__H__
-#error "Include metal/mutex.h instead of metal/zephyr/mutex.h"
+#error "Do not include this file directly, include <metal/mutex.h> instead"
 #endif
 
 #ifndef __METAL_ZEPHYR_MUTEX__H__

--- a/lib/system/zephyr/sleep.h
+++ b/lib/system/zephyr/sleep.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_SLEEP__H__
-#error "Include metal/sleep.h instead of metal/zephyr/sleep.h"
+#error "Do not include this file directly, include <metal/sleep.h> instead"
 #endif
 
 #ifndef __METAL_ZEPHYR_SLEEP__H__

--- a/lib/system/zephyr/sys.h
+++ b/lib/system/zephyr/sys.h
@@ -10,7 +10,7 @@
  */
 
 #ifndef __METAL_SYS__H__
-#error "Include metal/sys.h instead of metal/zephyr/sys.h"
+#error "Do not include this file directly, include <metal/sys.h> instead"
 #endif
 
 #ifndef __METAL_ZEPHYR_SYS__H__


### PR DESCRIPTION
Several of these were not correct in some spots. Use the automatic replacement to fill this in when installing the headers.