### PR TITLE
CI: Update to Zephyr 4.4 to fix cmake dependency

### DIFF
--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -74,8 +74,8 @@ build_zephyr(){
 	west init --mr $ZEPHYR_VERSION ./zephyrproject || exit 1
 	cd ./zephyrproject || exit 1
 	west update --narrow || exit 1
-	west zephyr-export || exit 1
 	west packages pip --install || exit 1
+	west zephyr-export || exit 1
 
 	echo  "Zephyr sdk install"
 	cd ./zephyr &&

--- a/.github/actions/build_ci/entrypoint.sh
+++ b/.github/actions/build_ci/entrypoint.sh
@@ -3,7 +3,7 @@
 readonly TARGET="$1"
 
 # Known good version for PR testing
-ZEPHYR_VERSION=v4.3.0
+ZEPHYR_VERSION=v4.4.0
 
 FREERTOS_ZIP_URL=https://sourceforge.net/projects/freertos/files/FreeRTOS/V10.0.1/FreeRTOSv10.0.1.zip
 


### PR DESCRIPTION
Zephyr 4.3 does not properly support CMake 4.x.
The command "west sdk install" fails because of some Zephyr CMake files.

The issue has been fixed in Zephyr 4.4. Upgrade to Zephyr 4.4 instead of trying to apply a temporary fix for Zephyr 4.3.

I also inverted west commands according to the Zephyr 4.4 documentation. This inversion allows the tests to pass on the latest main.