### PR TITLE
linux: remove sudo escalation from probe_driver and fix CI test setup

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -68,6 +68,7 @@ jobs:
         make
     - name: execute test
       run: |
+        sudo modprobe uio uio_pdrv_genirq uio_dmem_genirq
         cd build
         make test
     - name: test logs

--- a/lib/system/linux/device.c
+++ b/lib/system/linux/device.c
@@ -1113,21 +1113,6 @@ static int metal_linux_probe_driver(struct linux_bus *lbus,
 		ldrv->sdrv = sysfs_open_driver(lbus->bus_name, ldrv->drv_name);
 	}
 
-	/* Try sudo probing the module and then open the driver. */
-	if (!ldrv->sdrv) {
-		ret = snprintf(command, sizeof(command),
-			       "sudo modprobe %s > /dev/null 2>&1", ldrv->mod_name);
-		if (ret >= (int)sizeof(command))
-			return -EOVERFLOW;
-		ret = system(command);
-		if (ret < 0) {
-			metal_log(METAL_LOG_WARNING,
-				  "%s: executing system command '%s' failed.\n",
-				  __func__, command);
-		}
-		ldrv->sdrv = sysfs_open_driver(lbus->bus_name, ldrv->drv_name);
-	}
-
 	/* If all else fails... */
 	return ldrv->sdrv ? 0 : -ENODEV;
 }


### PR DESCRIPTION
1. Removes the `sudo modprobe` fallback from `metal_linux_probe_driver()`                                                                                                                                                                    
    in `lib/system/linux/device.c`. A library must not silently attempt                                                        
    privilege escalation on behalf of its caller - this is a security                                                                                                                                                                         
    concern and fails on embedded/production systems where `sudo`
    is absent or not configured for password-less use.

2. Updates the CI nonreg test workflow to explicitly load the required                                                                                                                                                                       
    UIO kernel modules (`uio`, `uio_pdrv_genirq`, `uio_dmem_genirq`)                                                                                                                                                                          
    before running `make test`, since the environment (& not the library)                                                                                                                                                                    
    is responsible for module loading
